### PR TITLE
Refinements

### DIFF
--- a/source/services/autosaveDialog/autosaveDialog.controller.tests.ts
+++ b/source/services/autosaveDialog/autosaveDialog.controller.tests.ts
@@ -52,20 +52,18 @@ module rl.ui.services.autosaveDialog {
 		});
 
 		function buildController(formGetter?: Sinon.SinonSpy, form?: any, formName?: string): void {
-			var bindings: any = {
+			var newScope: any = {
 				form: formName,
 				formGetter: formGetter,
 				setForm: setForm,
 			};
-
-			var newScope: any = {};
 
 			if (formName != null) {
 				newScope[formName] = form;
 			}
 
 			var controllerResult: test.IControllerResult<AutosaveDialogController>
-				= test.angularFixture.controllerWithBindings<AutosaveDialogController>(controllerName, bindings, null, newScope);
+				= test.angularFixture.controllerWithBindings<AutosaveDialogController>(controllerName, null, null, newScope);
 
 			scope = <IAutosaveDialogScope>controllerResult.scope;
 			dialog = controllerResult.controller;

--- a/source/services/autosaveDialog/autosaveDialog.controller.ts
+++ b/source/services/autosaveDialog/autosaveDialog.controller.ts
@@ -17,19 +17,19 @@ module rl.ui.services.autosaveDialog {
 		data: any;
 
 		static $inject: string[] = ['$scope'];
-		constructor(private $scope: ng.IScope) {
-			if (this.form != null) {
-				var unbind: Function = $scope.$watch(this.form, (form: ng.IFormController): void => {
+		constructor(private $scope: IAutosaveDialogScope) {
+			if ($scope.form != null) {
+				var unbind: Function = $scope.$watch($scope.form, (form: ng.IFormController): void => {
 					if (form != null) {
-						this.setForm(form);
+						$scope.setForm(form);
 						unbind();
 					}
 				});
 			}
-			else if (this.formGetter != null) {
-				var unbind: Function = $scope.$watch((): any => { return this.formGetter($scope); }, (form: ng.IFormController): void => {
+			else if ($scope.formGetter != null) {
+				var unbind: Function = $scope.$watch((): any => { return $scope.formGetter($scope); }, (form: ng.IFormController): void => {
 					if (form != null) {
-						this.setForm(form);
+						$scope.setForm(form);
 						unbind();
 					}
 				});

--- a/source/services/autosaveDialog/autosaveDialog.service.tests.ts
+++ b/source/services/autosaveDialog/autosaveDialog.service.tests.ts
@@ -77,7 +77,7 @@ module rl.ui.services.autosaveDialog {
 			sinon.assert.calledWith(autosaveFactory.getInstance, save, null, validate);
 
 			expect(scope.formGetter).to.equal(formGetter);
-			expect(scope.data).to.equal(data);
+			expect(scope.dialog).to.equal(data);
 
 			sinon.assert.calledOnce(<Sinon.SinonSpy>dialog.open);
 			var dialogOptions: IAutosaveDialogSettings = dialog.open.firstCall.args[0];

--- a/source/services/autosaveDialog/autosaveDialog.service.ts
+++ b/source/services/autosaveDialog/autosaveDialog.service.ts
@@ -47,7 +47,7 @@ module rl.ui.services.autosaveDialog {
 		form?: string;
 		formGetter?: { (scope: ng.IScope): ng.IFormController };
 		setForm(form: ng.IFormController): void;
-		data: any;
+		dialog: any;
 	}
 
 	export class AutosaveDialogService implements IAutosaveDialogService {
@@ -73,12 +73,11 @@ module rl.ui.services.autosaveDialog {
 			scope.formGetter = options.formGetter;
 			scope.setForm = this.setForm;
 			this.data = options.data;
-			scope.data = options.data;
+			scope.dialog = options.data;
 
 			var dialogOptions: IDialogSettings = <IDialogSettings>options;
 			dialogOptions.controller = controllerName;
-			dialogOptions.controllerAs = 'dialog';
-			dialogOptions.bindToController = true;
+			dialogOptions.controllerAs = 'controller';
 
 			return this.dialog.open(options, this.autosaveCloseHandler);
 		}

--- a/source/services/autosaveDialog/autosaveDialog.service.ts
+++ b/source/services/autosaveDialog/autosaveDialog.service.ts
@@ -87,7 +87,7 @@ module rl.ui.services.autosaveDialog {
 				return true;
 			}
 
-			var canClose: boolean = this.autosave.autosave(this.data);
+			return this.autosave.autosave(this.data);
 		}
 
 		private setForm: { (form: ng.IFormController): void } = (form: ng.IFormController): void => {

--- a/source/services/dialog/baseDialog/baseDialog.controller.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.controller.tests.ts
@@ -5,6 +5,7 @@
 /// <reference path='../../../../typings/chaiAssertions.d.ts' />
 /// <reference path='../../../../libraries/typescript-angular-utilities/typings/utility.d.ts' />
 
+/// <reference path='baseDialog.module.ts' />
 /// <reference path='baseDialog.controller.ts' />
 
 module rl.ui.services.dialog.baseDialog {
@@ -52,9 +53,9 @@ module rl.ui.services.dialog.baseDialog {
 			sinon.assert.calledOnce(baseDialog.modalClosing);
 		});
 
-		function buildController(dialogController?: any, controllerName?: string): void {
+		function buildController(dialogController?: any, dialogControllerName?: string): void {
 			let newScope: any = {
-				modalController: controllerName,
+				modalController: dialogControllerName,
 			};
 
 			$controller = sinon.spy((): any => { return dialogController; });

--- a/source/services/dialog/baseDialog/baseDialog.controller.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.controller.tests.ts
@@ -40,7 +40,7 @@ module rl.ui.services.dialog.baseDialog {
 			sinon.assert.calledOnce($controller);
 			let args: any = $controller.firstCall.args;
 			expect(args[0]).to.equal('test');
-			expect(args[1].scope).to.equal(scope);
+			expect(args[1].$scope).to.equal(scope);
 
 			expect(dialog).to.equal(dialogController);
 		});

--- a/source/services/dialog/baseDialog/baseDialog.controller.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.controller.tests.ts
@@ -1,0 +1,69 @@
+/// <reference path='../../../../typings/chai/chai.d.ts' />
+/// <reference path='../../../../typings/mocha/mocha.d.ts' />
+/// <reference path='../../../../typings/sinon/sinon.d.ts' />
+/// <reference path='../../../../typings/angularMocks.d.ts' />
+/// <reference path='../../../../typings/chaiAssertions.d.ts' />
+/// <reference path='../../../../libraries/typescript-angular-utilities/typings/utility.d.ts' />
+
+/// <reference path='baseDialog.controller.ts' />
+
+module rl.ui.services.dialog.baseDialog {
+	import test = rl.utilities.services.test;
+
+	interface IBaseDialogMock {
+		modalClosing: Sinon.SinonSpy;
+	}
+
+	describe('BaseDialogController', () => {
+		let scope: ng.IScope;
+		let dialog: any;
+		let $controller: Sinon.SinonSpy;
+		let baseDialog: IBaseDialogMock;
+
+		beforeEach(() => {
+			angular.mock.module(moduleName);
+
+			baseDialog = {
+				modalClosing: sinon.spy(),
+			};
+
+			test.angularFixture.mock({
+				baseDialog: baseDialog,
+			});
+		});
+
+		it('should return the dialog controller as the controller instance', (): void => {
+			let dialogController: any = { data: 1 };
+			buildController(dialogController, 'test');
+
+			sinon.assert.calledOnce($controller);
+			let args: any = $controller.firstCall.args;
+			expect(args[0]).to.equal('test');
+			expect(args[1].scope).to.equal(scope);
+
+			expect(dialog).to.equal(dialogController);
+		});
+
+		it('should call modalClosing on the baseDialog service when the modal closes', (): void => {
+			buildController();
+
+			scope.$broadcast('modal.closing');
+
+			sinon.assert.calledOnce(baseDialog.modalClosing);
+		});
+
+		function buildController(dialogController?: any, controllerName?: string): void {
+			let newScope: any = {
+				modalController: controllerName,
+			};
+
+			$controller = sinon.spy((): any => { return dialogController; });
+
+			let controllerResult: test.IControllerResult<any>
+				= test.angularFixture.controllerWithBindings<any>(controllerName, null, { $controller: $controller }, newScope);
+
+			scope = controllerResult.scope;
+			dialog = controllerResult.controller;
+		}
+	});
+}

--- a/source/services/dialog/baseDialog/baseDialog.controller.ts
+++ b/source/services/dialog/baseDialog/baseDialog.controller.ts
@@ -12,7 +12,7 @@ module rl.ui.services.dialog.baseDialog {
 	}
 
 	export class BaseDialogController {
-		static $inject: string[] = ['$scope', '$controller', baseDialog.serviceName];
+		static $inject: string[] = ['$scope', '$controller', serviceName];
 		constructor($scope: IBaseDialogScope
 				, $controller: ng.IControllerService
 				, baseDialog: BaseDialogService) {

--- a/source/services/dialog/baseDialog/baseDialog.controller.ts
+++ b/source/services/dialog/baseDialog/baseDialog.controller.ts
@@ -12,7 +12,7 @@ module rl.ui.services.dialog.baseDialog {
 	}
 
 	export class BaseDialogController {
-		static $inject: string[] = ['$scope', '$controller', serviceName];
+		static $inject: string[] = ['$scope', '$controller', baseDialog.serviceName];
 		constructor($scope: IBaseDialogScope
 				, $controller: ng.IControllerService
 				, baseDialog: BaseDialogService) {

--- a/source/services/dialog/baseDialog/baseDialog.controller.ts
+++ b/source/services/dialog/baseDialog/baseDialog.controller.ts
@@ -1,0 +1,30 @@
+// /// <reference path='../../../../typings/angularjs/angular.d.ts' />
+
+/// <reference path='baseDialog.service.ts' />
+
+module rl.ui.services.dialog.baseDialog {
+	'use strict';
+
+	export var controllerName: string = 'BaseDialogController';
+
+	export interface IBaseDialogScope extends ng.IScope {
+		modalController: string | Function;
+	}
+
+	export class BaseDialogController {
+		static $inject: string[] = ['$scope', '$controller', serviceName];
+		constructor($scope: IBaseDialogScope
+				, $controller: ng.IControllerService
+				, baseDialog: BaseDialogService) {
+			let controller: any;
+
+			if ($scope.modalController != null) {
+				controller = $controller(<any>$scope.modalController, { $scope: $scope });
+			}
+
+			$scope.$on('modal.closing', baseDialog.modalClosing);
+
+			return controller;
+		}
+	}
+}

--- a/source/services/dialog/baseDialog/baseDialog.module.ts
+++ b/source/services/dialog/baseDialog/baseDialog.module.ts
@@ -1,0 +1,16 @@
+// /// <reference path='../../../typings/angularjs/angular.d.ts' />
+// /// <reference path='../../../typings/angular-ui-bootstrap/angular-ui-bootstrap.d.ts' />
+// /// <reference path='../../../typings/lodash/lodash.d.ts' />
+
+/// <reference path='baseDialog.controller.ts' />
+/// <reference path='baseDialog.service.ts' />
+
+module rl.ui.services.dialog.baseDialog {
+	'use strict';
+
+	export var moduleName: string = 'rl.ui.services.dialog.baseDialog';
+
+	angular.module(moduleName, [])
+		.controller(controllerName, BaseDialogController)
+		.service(serviceName, BaseDialogService);
+}

--- a/source/services/dialog/baseDialog/baseDialog.service.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.tests.ts
@@ -1,14 +1,13 @@
-/// <reference path='../../../typings/chai/chai.d.ts' />
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-/// <reference path='../../../typings/sinon/sinon.d.ts' />
-/// <reference path='../../../typings/angularMocks.d.ts' />
-/// <reference path='../../../typings/chaiAssertions.d.ts' />
-/// <reference path='../../../libraries/typescript-angular-utilities/typings/utility.d.ts' />
+/// <reference path='../../../../typings/chai/chai.d.ts' />
+/// <reference path='../../../../typings/mocha/mocha.d.ts' />
+/// <reference path='../../../../typings/sinon/sinon.d.ts' />
+/// <reference path='../../../../typings/angularMocks.d.ts' />
+/// <reference path='../../../../typings/chaiAssertions.d.ts' />
+/// <reference path='../../../../libraries/typescript-angular-utilities/typings/utility.d.ts' />
 
-/// <reference path='dialog.service.ts' />
-/// <reference path='baseDialogImplementation.service.ts' />
+/// <reference path='baseDialog.service.ts' />
 
-module rl.ui.services.dialog {
+module rl.ui.services.dialog.baseDialog {
 	import test = rl.utilities.services.test;
 
 	interface IModalMock {
@@ -30,8 +29,8 @@ module rl.ui.services.dialog {
 				$modal: $modal,
 			});
 
-			var services: any = test.angularFixture.inject(baseDialogServiceName);
-			baseDialog = services[baseDialogServiceName];
+			var services: any = test.angularFixture.inject(serviceName);
+			baseDialog = services[serviceName];
 		});
 
 		it('should call the closeHandler when the dialog closes', (): void => {

--- a/source/services/dialog/baseDialog/baseDialog.service.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.tests.ts
@@ -5,6 +5,7 @@
 /// <reference path='../../../../typings/chaiAssertions.d.ts' />
 /// <reference path='../../../../libraries/typescript-angular-utilities/typings/utility.d.ts' />
 
+/// <reference path='baseDialog.module.ts' />
 /// <reference path='baseDialog.service.ts' />
 
 module rl.ui.services.dialog.baseDialog {

--- a/source/services/dialog/baseDialog/baseDialog.service.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.tests.ts
@@ -36,7 +36,7 @@ module rl.ui.services.dialog.baseDialog {
 
 		it('should call the closeHandler when the dialog closes', (): void => {
 			let closeHandler: Sinon.SinonSpy = sinon.spy((): boolean => { return true; });
-			baseDialog.open({}, closeHandler);
+			baseDialog.open(null, closeHandler);
 
 			baseDialog.modalClosing(null, null, true);
 
@@ -46,7 +46,7 @@ module rl.ui.services.dialog.baseDialog {
 
 		it('should prevent the dialog from closing if the close handler returns false', (): void => {
 			let closeHandler: Sinon.SinonSpy = sinon.spy((): boolean => { return false; });
-			baseDialog.open({}, closeHandler);
+			baseDialog.open(null, closeHandler);
 
 			var event: any = {
 				preventDefault: sinon.spy(),

--- a/source/services/dialog/baseDialog/baseDialog.service.tests.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.tests.ts
@@ -35,7 +35,7 @@ module rl.ui.services.dialog.baseDialog {
 
 		it('should call the closeHandler when the dialog closes', (): void => {
 			let closeHandler: Sinon.SinonSpy = sinon.spy((): boolean => { return true; });
-			baseDialog.open(null, closeHandler);
+			baseDialog.open({}, closeHandler);
 
 			baseDialog.modalClosing(null, null, true);
 
@@ -45,7 +45,7 @@ module rl.ui.services.dialog.baseDialog {
 
 		it('should prevent the dialog from closing if the close handler returns false', (): void => {
 			let closeHandler: Sinon.SinonSpy = sinon.spy((): boolean => { return false; });
-			baseDialog.open(null, closeHandler);
+			baseDialog.open({}, closeHandler);
 
 			var event: any = {
 				preventDefault: sinon.spy(),

--- a/source/services/dialog/baseDialog/baseDialog.service.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.ts
@@ -3,12 +3,10 @@
 // /// <reference path='../../../typings/lodash/lodash.d.ts' />
 
 /// <reference path='../dialog.service.ts' />
-/// <reference path='baseDialog.controller.ts' />
 
 module rl.ui.services.dialog.baseDialog {
 	'use strict';
 
-	export var moduleName: string = 'rl.ui.services.dialog.baseDialog';
 	export var serviceName: string = 'baseDialog';
 
 	export interface IBaseDialogService extends IDialogService<ng.ui.bootstrap.IModalSettings> { }
@@ -52,8 +50,4 @@ module rl.ui.services.dialog.baseDialog {
 			return options;
 		}
 	}
-
-	angular.module(moduleName, [])
-		.controller(controllerName, BaseDialogController)
-		.service(serviceName, BaseDialogService);
 }

--- a/source/services/dialog/baseDialog/baseDialog.service.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.ts
@@ -2,13 +2,14 @@
 // /// <reference path='../../../typings/angular-ui-bootstrap/angular-ui-bootstrap.d.ts' />
 // /// <reference path='../../../typings/lodash/lodash.d.ts' />
 
-/// <reference path='dialog.service.ts' />
+/// <reference path='../dialog.service.ts' />
+/// <reference path='baseDialog.controller.ts' />
 
-module rl.ui.services.dialog {
+module rl.ui.services.dialog.baseDialog {
 	'use strict';
 
-	export var baseDialogServiceName: string = 'baseDialog';
-	export var baseDialogControllerName: string = 'BaseDialogController';
+	export var moduleName: string = 'rl.ui.services.dialog.baseDialog';
+	export var serviceName: string = 'baseDialog';
 
 	export interface IBaseDialogService extends IDialogService<ng.ui.bootstrap.IModalSettings> { }
 
@@ -46,30 +47,13 @@ module rl.ui.services.dialog {
 			}
 
 			modalScope.modalController = options.controller;
-			options.controller = baseDialogControllerName;
+			options.controller = controllerName;
 			options.scope = modalScope;
 			return options;
 		}
 	}
 
-	export interface IBaseDialogScope extends ng.IScope {
-		modalController: string | Function;
-	}
-
-	export class BaseDialogController {
-		static $inject: string[] = ['$scope', '$controller', baseDialogServiceName];
-		constructor($scope: IBaseDialogScope
-				, $controller: ng.IControllerService
-				, baseDialog: BaseDialogService) {
-			let controller: any;
-
-			if ($scope.modalController != null) {
-				controller = $controller(<any>$scope.modalController, { $scope: $scope });
-			}
-
-			$scope.$on('modal.closing', baseDialog.modalClosing);
-
-			return controller;
-		}
-	}
+	angular.module(moduleName, [])
+		.controller(controllerName, BaseDialogController)
+		.service(serviceName, BaseDialogService);
 }

--- a/source/services/dialog/baseDialog/baseDialog.service.ts
+++ b/source/services/dialog/baseDialog/baseDialog.service.ts
@@ -38,6 +38,10 @@ module rl.ui.services.dialog.baseDialog {
 		}
 
 		private configureModalSettings(options: ng.ui.bootstrap.IModalSettings): ng.ui.bootstrap.IModalSettings {
+			if (options == null) {
+				options = <any>{};
+			}
+
 			let modalScope: IBaseDialogScope = <IBaseDialogScope>options.scope;
 
 			if (modalScope == null) {

--- a/source/services/dialog/baseDialogImplementation.service.ts
+++ b/source/services/dialog/baseDialogImplementation.service.ts
@@ -12,15 +12,15 @@ module rl.ui.services.dialog {
 	export interface IBaseDialogService extends IDialogService<ng.ui.bootstrap.IModalSettings> { }
 
 	export class BaseDialogService implements IDialogImplementation<ng.ui.bootstrap.IModalSettings> {
+		private unbindWatcher: Function;
 		closeHandler: IDialogCloseHandler;
 
-		static $inject: string[] = ['$modal', '$rootScope'];
-		constructor(private $modal: ng.ui.bootstrap.IModalService, $rootScope: ng.IRootScopeService) {
-			$rootScope.$on('modal.closing', this.modalClosing);
-		}
+		static $inject: string[] = ['$modal'];
+		constructor(private $modal: ng.ui.bootstrap.IModalService) {}
 
 		open(options: ng.ui.bootstrap.IModalSettings, closeHandler?: IDialogCloseHandler): void {
 			this.closeHandler = closeHandler;
+			this.unbindWatcher = options.scope.$on('modal.closing', this.modalClosing);
 			this.$modal.open(options);
 		}
 
@@ -35,6 +35,8 @@ module rl.ui.services.dialog {
 			if (!canClose) {
 				event.preventDefault();
 			}
+
+			this.unbindWatcher();
 		}
 	}
 }

--- a/source/services/dialog/baseDialogImplementation.service.ts
+++ b/source/services/dialog/baseDialogImplementation.service.ts
@@ -9,6 +9,8 @@ module rl.ui.services.dialog {
 
 	export var baseDialogServiceName: string = 'baseDialog';
 
+	export interface IBaseDialogService extends IDialogService<ng.ui.bootstrap.IModalSettings> { }
+
 	export class BaseDialogService implements IDialogImplementation<ng.ui.bootstrap.IModalSettings> {
 		closeHandler: IDialogCloseHandler;
 

--- a/source/services/dialog/dialog.service.ts
+++ b/source/services/dialog/dialog.service.ts
@@ -31,7 +31,7 @@ module rl.ui.services.dialog {
 
 	export interface IDialogServiceProvider<TDialogSettings> extends ng.IServiceProvider {
 		setImplementation(dialogImplementation: IDialogImplementation<TDialogSettings>): void;
-		$get(baseDialog: BaseDialogService): IDialogService<TDialogSettings>;
+		$get(baseDialog: baseDialog.BaseDialogService): IDialogService<TDialogSettings>;
 	}
 
 	export function dialogServiceProvider<TDialogSettings>(): IDialogServiceProvider<TDialogSettings> {
@@ -41,14 +41,14 @@ module rl.ui.services.dialog {
 			setImplementation: (dialogImplementation: IDialogImplementation<TDialogSettings>): void => {
 				this.dialogImplementation = dialogImplementation;
 			},
-			$get: (baseDialog: BaseDialogService): IDialogImplementation<TDialogSettings> => {
+			$get: (baseDialog: baseDialog.BaseDialogService): IDialogImplementation<TDialogSettings> => {
 				let dialogImplementation: IDialogImplementation<TDialogSettings> = this.dialogImplementation != null
 																				? this.dialogImplementation
 																				: baseDialog;
 				return new DialogService<TDialogSettings>(dialogImplementation);
 			},
 		};
-		provider.$get.$inject = [baseDialogServiceName];
+		provider.$get.$inject = [baseDialog.serviceName];
 		return provider;
 	}
 

--- a/source/services/dialog/dialog.service.ts
+++ b/source/services/dialog/dialog.service.ts
@@ -53,6 +53,7 @@ module rl.ui.services.dialog {
 	}
 
 	angular.module(moduleName, [])
+		.controller(baseDialogControllerName, BaseDialogController)
 		.service(baseDialogServiceName, BaseDialogService)
 		.provider(serviceName, dialogServiceProvider);
 }

--- a/source/services/dialog/dialog.service.ts
+++ b/source/services/dialog/dialog.service.ts
@@ -1,7 +1,7 @@
 // /// <reference path='../../../typings/angularjs/angular.d.ts' />
 // /// <reference path='../../../typings/angular-ui-bootstrap/angular-ui-bootstrap.d.ts' />
 
-/// <reference path='baseDialog/baseDialog.service.ts' />
+/// <reference path='baseDialog/baseDialog.module.ts' />
 
 module rl.ui.services.dialog {
 	'use strict';

--- a/source/services/dialog/dialog.service.ts
+++ b/source/services/dialog/dialog.service.ts
@@ -1,7 +1,7 @@
 // /// <reference path='../../../typings/angularjs/angular.d.ts' />
 // /// <reference path='../../../typings/angular-ui-bootstrap/angular-ui-bootstrap.d.ts' />
 
-/// <reference path='baseDialogImplementation.service.ts' />
+/// <reference path='baseDialog/baseDialog.service.ts' />
 
 module rl.ui.services.dialog {
 	'use strict';
@@ -52,8 +52,6 @@ module rl.ui.services.dialog {
 		return provider;
 	}
 
-	angular.module(moduleName, [])
-		.controller(baseDialogControllerName, BaseDialogController)
-		.service(baseDialogServiceName, BaseDialogService)
+	angular.module(moduleName, [baseDialog.moduleName])
 		.provider(serviceName, dialogServiceProvider);
 }


### PR DESCRIPTION
Fixed some issues with the base dialog implementation. Angular-ui doesn't broadcast the close event on the rootscope, so we had to get around this by providing a controller that extends the controller provided for the dialog with a listener for modal.closing on the scope. This isn't the prettiest solution, but it works.
