### PR TITLE
Require the slider js file directly into the slider file and remove t…

### DIFF
--- a/libraries/angular-bootstrap-slider/index.js
+++ b/libraries/angular-bootstrap-slider/index.js
@@ -1,3 +1,0 @@
-require('./bootstrap-slider.min.css');
-require('./bootstrap-slider.min');
-require('./slider');

--- a/libraries/angular-bootstrap-slider/slider.js
+++ b/libraries/angular-bootstrap-slider/slider.js
@@ -1,3 +1,6 @@
+require('./bootstrap-slider.min.css');
+var Slider = require('./bootstrap-slider.min');
+
 angular.module('ui.bootstrap-slider', [])
     .directive('slider', ['$parse', '$timeout', '$rootScope', function ($parse, $timeout, $rootScope) {
         return {

--- a/source/ui.module.ts
+++ b/source/ui.module.ts
@@ -5,7 +5,7 @@ import * as angular from 'angular';
 import 'angular-ui-bootstrap';
 import 'angular-sanitize';
 
-import '../libraries/angular-bootstrap-slider/index';
+import '../libraries/angular-bootstrap-slider/slider';
 
 import 'signature_pad';
 


### PR DESCRIPTION
…he index file altogether. The jquery slider library is smart enough to detect when AMD is used and return the slider class  instead of putting it on the global scope. This is actually a nicer way to handle this, as we can just require it in and we don't have to have the class cluttering the global namespace.
