### PR TITLE
Multi step spinner

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,6 +29,10 @@
         {
             "taskName": "clean",
             "args": ["run"]
+        },
+        {
+            "taskName": "publish.prep",
+            "args": ["run"]
         }
     ],
 	"problemMatcher": "$tsc"

--- a/source/components/multiStepIndicator/multiStepIndicator.html
+++ b/source/components/multiStepIndicator/multiStepIndicator.html
@@ -3,7 +3,7 @@
 		<li ng-repeat="step in breadcrumb.steps" ng-click="step.onClick()"
 			ng-class="{ 'completed': step.isCompleted, 'current': step.isCurrent, 'active': !step.inactive }">
 			<div class="wrap">
-				<p class="title">{{step.title}}</p>
+				<p class="title">{{step.title}} <rl-busy loading="step.loading"></rl-busy></p>
 				<p class="subtitle">{{step.subtitle}}</p>
 			</div>
 		</li>

--- a/source/components/multiStepIndicator/multiStepIndicator.html
+++ b/source/components/multiStepIndicator/multiStepIndicator.html
@@ -1,0 +1,11 @@
+<div class="multi-step" ng-class="{ 'numbered': breadcrumb.numbered }">
+	<ol>
+		<li ng-repeat="step in breadcrumb.steps" ng-click="step.onClick()"
+			ng-class="{ 'completed': step.isCompleted, 'current': step.isCurrent, 'active': !step.inactive }">
+			<div class="wrap">
+				<p class="title">{{step.title}}</p>
+				<p class="subtitle">{{step.subtitle}}</p>
+			</div>
+		</li>
+	</ol>
+</div>

--- a/source/components/multiStepIndicator/multiStepIndicator.html
+++ b/source/components/multiStepIndicator/multiStepIndicator.html
@@ -1,7 +1,7 @@
 <div class="multi-step" ng-class="{ 'numbered': breadcrumb.numbered }">
 	<ol>
-		<li ng-repeat="step in breadcrumb.steps" ng-click="step.onClick()"
-			ng-class="{ 'completed': step.isCompleted, 'current': step.isCurrent, 'active': !step.inactive }">
+		<li ng-repeat="step in breadcrumb.steps" ng-click="breadcrumb.onClick(step)"
+			ng-class="{ 'completed': step.isCompleted, 'current': step.isCurrent, 'active': !step.inactive && !breadcrumb.anyLoading() }">
 			<div class="wrap">
 				<p class="title">{{step.title}} <rl-busy loading="step.loading"></rl-busy></p>
 				<p class="subtitle">{{step.subtitle}}</p>

--- a/source/components/multiStepIndicator/multiStepIndicator.tests.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.tests.ts
@@ -25,43 +25,46 @@ interface IStateServiceMock {
 }
 
 describe('MultiStepIndicatorController', () => {
-	var scope: angular.IScope;
-	var multiStepIndicator: MultiStepIndicatorController;
-	var stateMock: IStateServiceMock;
+	let scope: angular.IScope;
+	let multiStepIndicator: MultiStepIndicatorController;
+	let stateMock: IStateServiceMock;
+	let $q: angular.IQService;
 
 	beforeEach(() => {
 		angular.mock.module(moduleName);
 
+		let services: any = test.angularFixture.inject('$q');
+		$q = services.$q;
+
 		stateMock = {
-			go: sinon.spy(),
+			go: sinon.spy((): angular.IPromise<any> => { return $q.when(); }),
 			includes: sinon.spy((): boolean => { return false; }),
 		};
-
-		test.angularFixture.mock({
-			$state: stateMock,
-		});
 	});
 
 	it('should set inactive to true if no click handler or state name is provided', (): void => {
-		var step: IStep = <any>{};
+		let step: IStep = <any>{};
 		buildController([step]);
 		expect((<any>step).inactive).to.be.true;
 	});
 
 	it('should provide a default click handler that redirects to the specified state and sets the step to current if a state name is provided', (): void => {
-		var step: IStep = <any>{ stateName: 'state' };
+		let step: IStep = <any>{ stateName: 'state' };
 		buildController([step]);
 
 		step.onClick();
 
 		sinon.assert.calledOnce(stateMock.go);
 		sinon.assert.calledWith(stateMock.go, 'state');
+
+		scope.$digest();
+
 		expect(step.isCurrent).to.be.true;
 	});
 
 	it('should set the step to current if the specified state is already active', (): void => {
-		var step1: IStep = <any>{ stateName: 'state2', isCurrent: false };
-		var step2: IStep = <any>{ stateName: 'state1', isCurrent: false };
+		let step1: IStep = <any>{ stateName: 'state2', isCurrent: false };
+		let step2: IStep = <any>{ stateName: 'state1', isCurrent: false };
 		stateMock.includes = sinon.spy((name: string): boolean => { return name === step1.stateName; });
 		buildController([step1, step2]);
 
@@ -70,8 +73,8 @@ describe('MultiStepIndicatorController', () => {
 	});
 
 	function buildController(steps: IStep[]): void {
-		var controllerResult: test.IControllerResult<MultiStepIndicatorController>
-			= test.angularFixture.controllerWithBindings<MultiStepIndicatorController>(controllerName, { steps: steps });
+		let controllerResult: test.IControllerResult<MultiStepIndicatorController>
+			= test.angularFixture.controllerWithBindings<MultiStepIndicatorController>(controllerName, { steps: steps }, { $state: stateMock });
 
 		scope = <angular.IScope>controllerResult.scope;
 		multiStepIndicator = controllerResult.controller;

--- a/source/components/multiStepIndicator/multiStepIndicator.tests.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.tests.ts
@@ -88,6 +88,20 @@ describe('MultiStepIndicatorController', () => {
 		sinon.assert.notCalled(<Sinon.SinonSpy>step2.onClick);
 	});
 
+	it('should clear the spinner when the promise resolves', (): void => {
+		let step1: IConfiguredStep = <any>{ onClick: sinon.spy(), };
+		buildController([step1]);
+
+		multiStepIndicator.onClick(step1);
+
+		sinon.assert.calledOnce(<Sinon.SinonSpy>step1.onClick);
+		expect(step1.loading).to.be.true;
+
+		scope.$digest();
+
+		expect(step1.loading).to.be.false;
+	});
+
 	function buildController(steps: IStep[]): void {
 		let controllerResult: test.IControllerResult<MultiStepIndicatorController>
 			= test.angularFixture.controllerWithBindings<MultiStepIndicatorController>(controllerName, { steps: steps }, { $state: stateMock });

--- a/source/components/multiStepIndicator/multiStepIndicator.tests.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.tests.ts
@@ -12,6 +12,7 @@ import {
 	controllerName,
 	MultiStepIndicatorController,
 	IStep,
+	IConfiguredStep,
 } from './multiStepIndicator';
 
 import * as angular from 'angular';
@@ -70,6 +71,21 @@ describe('MultiStepIndicatorController', () => {
 
 		expect(step1.isCurrent).to.be.true;
 		expect(step2.isCurrent).to.be.false;
+	});
+
+	it('should show a spinner on the step and disable all clicks when the step is loading', (): void => {
+		let step1: IConfiguredStep = <any>{ onClick: sinon.spy(), };
+		let step2: IConfiguredStep = <any>{ onClick: sinon.spy(), };
+		buildController([step1, step2]);
+
+		multiStepIndicator.onClick(step1);
+
+		sinon.assert.calledOnce(<Sinon.SinonSpy>step1.onClick);
+		expect(step1.loading).to.be.true;
+
+		multiStepIndicator.onClick(step2);
+
+		sinon.assert.notCalled(<Sinon.SinonSpy>step2.onClick);
 	});
 
 	function buildController(steps: IStep[]): void {

--- a/source/components/multiStepIndicator/multiStepIndicator.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.ts
@@ -58,7 +58,7 @@ export class MultiStepIndicatorController {
 				if (this.object.isNullOrWhitespace(step.stateName)) {
 					step.inactive = true;
 				} else {
-					step.onClick = (): void => { this.redirectToState(step); };
+					step.onClick = (): angular.IPromise<void> => { return this.redirectToState(step); };
 
 					if (this.$state.includes(step.stateName)) {
 						step.isCurrent = true;
@@ -68,7 +68,7 @@ export class MultiStepIndicatorController {
 		});
 	}
 
-	private redirectToState: { (step: IConfiguredStep): void } = (step: IConfiguredStep): angular.IPromise<void> => {
+	private redirectToState(step: IConfiguredStep): angular.IPromise<void> {
 		return this.$state.go(step.stateName).then((): void => {
 			this.clearCurrentState();
 			step.isCurrent = true;

--- a/source/components/multiStepIndicator/multiStepIndicator.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.ts
@@ -24,6 +24,7 @@ export interface IStep {
 
 interface IConfiguredStep extends IStep {
 	inactive: boolean;
+	loading: boolean;
 }
 
 export class MultiStepIndicatorController {

--- a/source/components/multiStepIndicator/multiStepIndicator.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.ts
@@ -1,3 +1,5 @@
+// /// <reference path='../../../typings/commonjs.d.ts' />
+
 'use strict';
 
 import * as angular from 'angular';
@@ -66,19 +68,7 @@ function multiStepIndicator(): angular.IDirective {
 	'use strict';
 	return {
 		restrict: 'E',
-		template: `
-			<div class="multi-step" ng-class="{ 'numbered': breadcrumb.numbered }">
-				<ol>
-					<li ng-repeat="step in breadcrumb.steps" ng-click="step.onClick()"
-						ng-class="{ 'completed': step.isCompleted, 'current': step.isCurrent, 'active': !step.inactive }">
-						<div class="wrap">
-							<p class="title">{{step.title}}</p>
-							<p class="subtitle">{{step.subtitle}}</p>
-						</div>
-					</li>
-				</ol>
-			</div>
-		`,
+		template: require('./multiStepIndicator.html'),
 		controller: controllerName,
 		controllerAs: 'breadcrumb',
 		scope: {},

--- a/source/components/multiStepIndicator/multiStepIndicator.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.ts
@@ -22,13 +22,13 @@ export interface IStep {
 	isCurrent?: boolean;
 }
 
-interface IConfiguredStep extends IStep {
+export interface IConfiguredStep extends IStep {
 	inactive: boolean;
 	loading: boolean;
 }
 
 export class MultiStepIndicatorController {
-	steps: IStep[];
+	steps: IConfiguredStep[];
 
 	static $inject: string[] = ['$state', __object.serviceName];
 	constructor(private $state: angular.ui.IStateService
@@ -36,11 +36,23 @@ export class MultiStepIndicatorController {
 		this.configureSteps();
 	}
 
+	onClick(step: IConfiguredStep): void {
+		if (!this.anyLoading()) {
+			step.onClick();
+		}
+	}
+
+	anyLoading(): boolean {
+		return _.any(this.steps, (step: IConfiguredStep): boolean => {
+			return step.loading;
+		});
+	}
+
 	private configureSteps(): void {
-		_.each(this.steps, (step: IStep): void => {
+		_.each(this.steps, (step: IConfiguredStep): void => {
 			if (!_.isFunction(step.onClick)) {
 				if (this.object.isNullOrWhitespace(step.stateName)) {
-					(<IConfiguredStep>step).inactive = true;
+					step.inactive = true;
 				} else {
 					step.onClick = (): void => { this.redirectToState(step); };
 

--- a/source/components/multiStepIndicator/multiStepIndicator.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.ts
@@ -52,10 +52,13 @@ export class MultiStepIndicatorController {
 		});
 	}
 
-	private redirectToState: { (step: IStep): void } = (step: IStep): void => {
-		this.clearCurrentState();
-		this.$state.go(step.stateName);
-		step.isCurrent = true;
+	private redirectToState: { (step: IConfiguredStep): void } = (step: IConfiguredStep): void => {
+		step.loading = true;
+		this.$state.go(step.stateName).then((): void => {
+			this.clearCurrentState();
+			step.isCurrent = true;
+			step.loading = false;
+		});
 	}
 
 	private clearCurrentState(): void {


### PR DESCRIPTION
Implemented functionality for showing a spinner when executing a step's click event. This can be used either for the default click (state change) or for a consumer-specified click, if they return a promise. (If they don't, the spinner will just hide right away) Also disable further clicks until the promise resolves.
