### PR TITLE
We don't need an ng-hide for ngDisabled here, since this is inside of…

### DIFF
--- a/source/components/spinner/spinner.ts
+++ b/source/components/spinner/spinner.ts
@@ -41,7 +41,7 @@ function spinner($timeout: angular.ITimeoutService
 		template: `
 			<rl-generic-container selector="ngDisabled">
 				<template default>
-					<input name="{{name}}" class="spinner" ng-hide="ngDisabled" id="{{spinnerId}}" type="text" />
+					<input name="{{name}}" class="spinner" id="{{spinnerId}}" type="text" />
 				</template>
 				<template when-selector="true">
 					<div class="input-group" ng-show="prefix != null && postfix != null">


### PR DESCRIPTION
… a generic container. This is adding an unused watch, so removing it will give us a slight performance gain
