### PR TITLE
Allow message templates for message log

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,11 +1,8 @@
 // Karma default configuration
 
 var karmaSettings = require('gulp-utilities').karma.standard;
-var webpackRawLoader = require('./webpack.raw-loader');
+var config = require('./karma.shared.conf');
 
 module.exports = function (karma) {
-	var karmaConfig = karmaSettings(karma, ['test-bootstrapper.js']);
-	webpackRawLoader(karmaConfig.webpack);
-
-	karma.set(karmaConfig);
+	config(karma, karmaSettings);
 };

--- a/karma.debug.conf.js
+++ b/karma.debug.conf.js
@@ -1,11 +1,8 @@
 // Karma debug configuration
 
 var karmaSettings = require('gulp-utilities').karma.debug;
-var webpackRawLoader = require('./webpack.raw-loader');
+var config = require('./karma.shared.conf');
 
 module.exports = function (karma) {
-	var karmaConfig = karmaSettings(karma, ['test-bootstrapper.js']);
-	webpackRawLoader(karmaConfig.webpack);
-
-	karma.set(karmaConfig);
+	config(karma, karmaSettings);
 };

--- a/karma.full.conf.js
+++ b/karma.full.conf.js
@@ -1,11 +1,8 @@
 // Karma full browser configuration
 
 var karmaSettings = require('gulp-utilities').karma.full;
-var webpackRawLoader = require('./webpack.raw-loader');
+var config = require('./karma.shared.conf');
 
 module.exports = function (karma) {
-	var karmaConfig = karmaSettings(karma, ['test-bootstrapper.js']);
-	webpackRawLoader(karmaConfig.webpack);
-
-	karma.set(karmaConfig);
+	config(karma, karmaSettings);
 };

--- a/karma.shared.conf.js
+++ b/karma.shared.conf.js
@@ -1,0 +1,19 @@
+// Karma default configuration
+
+var webpackRawLoader = require('./webpack.raw-loader');
+
+module.exports = function (karma, karmaSettings) {
+	var karmaConfig = karmaSettings(karma, [
+		'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-alpha1/jquery.min.js',
+		'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.7/angular.min.js',
+		'test-bootstrapper.js',
+	]);
+	webpackRawLoader(karmaConfig.webpack);
+	karmaConfig.webpack.externals = {
+		'jquery': '$',
+		'angular': 'angular',
+	};
+
+	karma.set(karmaConfig);
+	return karmaConfig;
+};

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "moment": "^2.10.6",
     "ng-wig": "^2.2.0",
     "signature_pad": "~1.4.0",
-    "typescript-angular-utilities": "^2.3.1"
+    "typescript-angular-utilities": "^2.3.3"
   },
   "license": "GPL-3.0"
 }

--- a/source/components/genericContainer/genericContainer.tests.ts
+++ b/source/components/genericContainer/genericContainer.tests.ts
@@ -18,7 +18,6 @@ import {
 import * as angular from 'angular';
 import 'angular-mocks';
 
-
 describe('GenericContainerController', () => {
 	var controller: GenericContainerController;
 	var scope: angular.IScope;

--- a/source/components/messageLog/messageLog.directive.tests.ts
+++ b/source/components/messageLog/messageLog.directive.tests.ts
@@ -5,7 +5,9 @@
 
 'use strict';
 
-import { services } from 'typescript-angular-utilities';
+import { services, filters } from 'typescript-angular-utilities';
+import test = services.test;
+import __isEmpty = filters.isEmpty;
 
 import {
 	moduleName,
@@ -15,8 +17,6 @@ import {
 
 import * as angular from 'angular';
 import 'angular-mocks';
-
-import test = services.test;
 
 interface IMockMessageLogService {
 	visibleMessages: number[];
@@ -28,13 +28,14 @@ interface IMockMessageLogService {
 	getTopPage: Sinon.SinonSpy;
 }
 
-describe('MessageLogController', () => {
+describe('messageLog', () => {
 	var scope: angular.IScope;
 	var log: MessageLogController;
 	var messageLogService: IMockMessageLogService;
 
 	beforeEach(() => {
 		angular.mock.module(moduleName);
+		angular.mock.module(__isEmpty.moduleName);
 
 		messageLogService = {
 			visibleMessages: [1, 2, 3, 4, 5],
@@ -57,91 +58,126 @@ describe('MessageLogController', () => {
 		});
 	});
 
-	it('should set messages on the scope to the visible messages of the service', (): void => {
-		buildController();
-		scope.$digest();
+	describe('MessageLogController', () => {
+		it('should set messages on the scope to the visible messages of the service', (): void => {
+			buildController();
+			scope.$digest();
 
-		expect(log.messages).to.equal(messageLogService.visibleMessages);
+			expect(log.messages).to.equal(messageLogService.visibleMessages);
 
-		messageLogService.visibleMessages = [4, 5, 6, 7, 8];
-		scope.$digest();
+			messageLogService.visibleMessages = [4, 5, 6, 7, 8];
+			scope.$digest();
 
-		expect(log.messages).to.equal(messageLogService.visibleMessages);
+			expect(log.messages).to.equal(messageLogService.visibleMessages);
+		});
+
+		it('should set hasNextPage to the has forward messages flag on the service', (): void => {
+			buildController();
+			scope.$digest();
+
+			expect(log.hasNextPage).to.be.true;
+
+			messageLogService.hasForwardMessages = false;
+			scope.$digest();
+
+			expect(log.hasNextPage).to.be.false;
+		});
+
+		it('should set hasPreviousPage to the has backward messages flag on the service', (): void => {
+			buildController();
+			scope.$digest();
+
+			expect(log.hasPreviousPage).to.be.false;
+
+			messageLogService.hasBackwardMessages = true;
+			scope.$digest();
+
+			expect(log.hasPreviousPage).to.be.true;
+		});
+
+		it('should set the base loading flag when busy is set to true and clear all loading flags if busy is set to false on the service', (): void => {
+			buildController();
+			scope.$digest();
+
+			expect(log.loadingInitial).to.be.true;
+
+			messageLogService.busy = true;
+			scope.$digest();
+
+			expect(log.loading).to.be.true;
+
+			messageLogService.busy = false;
+			scope.$digest();
+
+			expect(log.loading).to.be.false;
+			expect(log.loadingInitial).to.be.false;
+		});
+
+		it('should set the page size on initialization', (): void => {
+			buildController();
+			expect(messageLogService.pageSize).to.equal(8);
+		});
+
+		it('should set the page size to the value specified on the scope', (): void => {
+			buildController(5);
+			expect(messageLogService.pageSize).to.equal(5);
+		});
+
+		it('should set loading older to true and call getNextPage on the service', (): void => {
+			buildController();
+			log.getOlder();
+			sinon.assert.calledOnce(messageLogService.getNextPage);
+		});
+
+		it('should set loading top to true and call getTopPage on the service', (): void => {
+			buildController();
+			log.getTop();
+			sinon.assert.calledOnce(messageLogService.getTopPage);
+		});
+
+		function buildController(pageSize?: number): void {
+			var bindings: any = {
+				pageSize: pageSize,
+			};
+
+			var controllerResult: test.IControllerResult<MessageLogController>
+				= test.angularFixture.controllerWithBindings<MessageLogController>(controllerName, bindings);
+
+			scope = controllerResult.scope;
+			log = controllerResult.controller;
+		}
 	});
 
-	it('should set hasNextPage to the has forward messages flag on the service', (): void => {
-		buildController();
-		scope.$digest();
+	describe('rlMessageLog directive', (): void => {
+		it('should add a message template and selector', (): void => {
+			var directiveResult: test.IDirectiveResult<MessageLogController> =
+				test.angularFixture.directive<MessageLogController>('rlMessageLog', `
+				<rl-message-log service="logService" selector="selectorFunction">
+					<template when-selector="true">
+						<p>Message is greater than 3</p>
+					</template>
+				</rl-message-log>
+				`, <any> {
+					logService: messageLogService,
+					selectorFunction: function(entry) {
+						return entry > 3;
+					},
+				});
 
-		expect(log.hasNextPage).to.be.true;
+			expect(directiveResult.controller.getEntrySelector(<any> 4)).to.be.true;
+			expect(directiveResult.controller.getEntrySelector(<any> 3)).to.be.false;
 
-		messageLogService.hasForwardMessages = false;
-		scope.$digest();
+			expect(directiveResult.controller.templates['true']).to.contain('<p>Message is greater than 3</p>');
+		});
 
-		expect(log.hasNextPage).to.be.false;
+		it('should have neither a selector or templates', (): void => {
+			var directiveResult: test.IDirectiveResult<MessageLogController> =
+				test.angularFixture.directive<MessageLogController>('rlMessageLog',
+					'<rl-message-log service="logService"></rl-message-log>',
+					<any> { logService: messageLogService });
+
+			expect(directiveResult.controller.getEntrySelector(<any> 1)).to.be.undefined;
+		});
 	});
-
-	it('should set hasPreviousPage to the has backward messages flag on the service', (): void => {
-		buildController();
-		scope.$digest();
-
-		expect(log.hasPreviousPage).to.be.false;
-
-		messageLogService.hasBackwardMessages = true;
-		scope.$digest();
-
-		expect(log.hasPreviousPage).to.be.true;
-	});
-
-	it('should set the base loading flag when busy is set to true and clear all loading flags if busy is set to false on the service', (): void => {
-		buildController();
-		scope.$digest();
-
-		expect(log.loadingInitial).to.be.true;
-
-		messageLogService.busy = true;
-		scope.$digest();
-
-		expect(log.loading).to.be.true;
-
-		messageLogService.busy = false;
-		scope.$digest();
-
-		expect(log.loading).to.be.false;
-		expect(log.loadingInitial).to.be.false;
-	});
-
-	it('should set the page size on initialization', (): void => {
-		buildController();
-		expect(messageLogService.pageSize).to.equal(8);
-	});
-
-	it('should set the page size to the value specified on the scope', (): void => {
-		buildController(5);
-		expect(messageLogService.pageSize).to.equal(5);
-	});
-
-	it('should set loading older to true and call getNextPage on the service', (): void => {
-		buildController();
-		log.getOlder();
-		sinon.assert.calledOnce(messageLogService.getNextPage);
-	});
-
-	it('should set loading top to true and call getTopPage on the service', (): void => {
-		buildController();
-		log.getTop();
-		sinon.assert.calledOnce(messageLogService.getTopPage);
-	});
-
-	function buildController(pageSize?: number): void {
-		var bindings: any = {
-			pageSize: pageSize,
-		};
-
-		var controllerResult: test.IControllerResult<MessageLogController>
-			= test.angularFixture.controllerWithBindings<MessageLogController>(controllerName, bindings);
-
-		scope = controllerResult.scope;
-		log = controllerResult.controller;
-	}
 });
+

--- a/source/components/messageLog/messageLog.directive.ts
+++ b/source/components/messageLog/messageLog.directive.ts
@@ -17,6 +17,8 @@ import { IMessageLogDataService, IMessageLog, IMessage, factoryName, IMessageLog
 
 import { IGenericTemplate } from '../genericContainer/genericContainer';
 
+import { ITemplateLoader, serviceName as templateLoaderService } from '../../services/templateLoader/templateLoader.service';
+
 export var directiveName: string = 'rlMessageLog';
 export var controllerName: string = 'MessageLogController';
 
@@ -101,9 +103,15 @@ interface IMessageLogScope {
 
 }
 
-messageLog.$inject = ['$interpolate', jqueryServiceName, __object.serviceName];
+messageLog.$inject = [
+	'$interpolate',
+	jqueryServiceName,
+	templateLoaderService,
+	__object.serviceName,
+];
 export function messageLog($interpolate: angular.IInterpolateService,
 							jquery: IJQueryUtility,
+							templateLoader: ITemplateLoader,
 							object: __object.IObjectUtility): angular.IDirective {
 	'use strict';
 	return {
@@ -124,25 +132,7 @@ export function messageLog($interpolate: angular.IInterpolateService,
 			   attributes: angular.IAttributes,
 			   controller: MessageLogController,
 			   transclude: angular.ITranscludeFunction): void => {
-			controller.templates = {};
-
-			// Load templates from the DOM
-			transclude((clone: angular.IAugmentedJQuery,
-						transclusionScope: angular.IScope): void => {
-				var templates: JQuery = clone.filter('template');
-
-				templates.each((index: number,
-								template: Element): void => {
-					var templateElement: angular.IAugmentedJQuery = angular.element(template);
-					var templateHtml: string = templateElement.html();
-
-					var triggerAttribute: string = templateElement.attr('when-selector');
-					if (!object.isNullOrWhitespace(triggerAttribute)) {
-						var trigger: string = $interpolate(triggerAttribute)(transclusionScope);
-						controller.templates[trigger] = templateHtml;
-					}
-				});
-			});
+			controller.templates = templateLoader.loadTemplates(transclude).templates;
 		}
 	};
 }

--- a/source/components/messageLog/messageLog.directive.ts
+++ b/source/components/messageLog/messageLog.directive.ts
@@ -5,8 +5,17 @@
 import * as ng from 'angular';
 
 import { services } from 'typescript-angular-utilities';
+import __object = services.object;
+
+import {
+	moduleName as jqueryModuleName,
+	serviceName as jqueryServiceName,
+	IJQueryUtility,
+} from '../../services/jquery/jquery.service';
 
 import { IMessageLogDataService, IMessageLog, IMessage, factoryName, IMessageLogFactory } from './messageLog.service';
+
+import { IGenericTemplate } from '../genericContainer/genericContainer';
 
 export var directiveName: string = 'rlMessageLog';
 export var controllerName: string = 'MessageLogController';
@@ -15,18 +24,23 @@ export interface IMessageLogBindings {
 	pageSize: number;
 	service: IMessageLogDataService;
 	messageLogBinding: IMessageLog;
+
+	selector: { (IMessage): any } | string;
 }
 
-export class MessageLogController {
+export class MessageLogController implements IMessageLogBindings {
 	// bindings
 	pageSize: number;
 	service: IMessageLogDataService;
 	messageLogBinding: IMessageLog;
+	selector: { (IMessage): any } | string;
 
 	messages: IMessage[];
 	hasNextPage: boolean;
 	hasPreviousPage: boolean;
 	messageLog: IMessageLog;
+
+	templates: any;
 
 	loading: boolean;
 	loadingInitial: boolean;
@@ -65,6 +79,14 @@ export class MessageLogController {
 		this.messageLog.pageSize = this.pageSize != null ? this.pageSize : 8;
 	}
 
+	getEntrySelector(entry: IMessage): any {
+		if (_.isString(this.selector)) {
+			return entry[<string> this.selector];
+		} else if (_.isFunction(this.selector)) {
+			return (<{ (IMessage): any }> this.selector)(entry);
+		}
+	}
+
 	getOlder(): ng.IPromise<void> {
 		return this.messageLog.getNextPage();
 	}
@@ -74,18 +96,53 @@ export class MessageLogController {
 	}
 }
 
-export function messageLog(): ng.IDirective {
+interface IMessageLogScope {
+	defaultTemplate: IGenericTemplate | string;
+
+}
+
+messageLog.$inject = ['$interpolate', jqueryServiceName, __object.serviceName];
+export function messageLog($interpolate: angular.IInterpolateService,
+							jquery: IJQueryUtility,
+							object: __object.IObjectUtility): angular.IDirective {
 	'use strict';
 	return {
 		restrict: 'E',
 		template: require('./messageLog.html'),
+		transclude: true,
 		controller: controllerName,
 		controllerAs: 'log',
 		scope: {},
 		bindToController: {
 			service: '=',
+			selector: '=',
 			pageSize: '=',
 			messageLogBinding: '=messageLog',
 		},
+		link: (scope: angular.IScope,
+			   element: angular.IAugmentedJQuery,
+			   attributes: angular.IAttributes,
+			   controller: MessageLogController,
+			   transclude: angular.ITranscludeFunction): void => {
+			controller.templates = {};
+
+			// Load templates from the DOM
+			transclude((clone: angular.IAugmentedJQuery,
+						transclusionScope: angular.IScope): void => {
+				var templates: JQuery = clone.filter('template');
+
+				templates.each((index: number,
+								template: Element): void => {
+					var templateElement: angular.IAugmentedJQuery = angular.element(template);
+					var templateHtml: string = templateElement.html();
+
+					var triggerAttribute: string = templateElement.attr('when-selector');
+					if (!object.isNullOrWhitespace(triggerAttribute)) {
+						var trigger: string = $interpolate(triggerAttribute)(transclusionScope);
+						controller.templates[trigger] = templateHtml;
+					}
+				});
+			});
+		}
 	};
 }

--- a/source/components/messageLog/messageLog.html
+++ b/source/components/messageLog/messageLog.html
@@ -1,19 +1,23 @@
 <div>
 	<rl-busy loading="log.loadingInitial" size="2x"></rl-busy>
 	<div class="content-group" ng-repeat="entry in log.messages">
-		<div ng-bind-html="entry.message"></div>
-		<div class="byline">{{entry.createdBy}}</div>
-		<div class="byline">{{entry.createdDate}} {{entry.createdTime}} UTC</div>
+		<rl-generic-container selector="log.getEntrySelector(entry)" templates="log.templates">
+			<template default>
+				<div ng-bind-html="entry.message"></div>
+				<div class="byline">{{entry.createdBy}}</div>
+				<div class="byline">{{entry.createdDate}} {{entry.createdTime}} UTC</div>
+			</template>
+		</rl-generic-container>
 	</div>
 	<div class="content-group" ng-if="(log.messages | isEmpty) && !log.loadingInitial">No existing messages</div>
 	<div class="row">
 		<div class="col-xs-12">
 			<div class="text-center">
-				<rl-button-async type="default" action="log.getTopPage()" ng-disabled="log.loading" right-aligned="true">
+				<rl-button-async type="default" action="log.getTop()" ng-disabled="log.loading" button-right-aligned="true">
 					<span ng-show="log.hasPreviousPage">Top</span>
 					<span ng-hide="log.hasPreviousPage">Refresh</span>
 				</rl-button-async>
-				<rl-button-async type="default" ng-disabled="log.hasNextPage == false || log.loading" action="log.getNextPage()">
+				<rl-button-async type="default" ng-disabled="log.hasNextPage == false || log.loading" action="log.getOlder()">
 					Older <i class="fa fa-chevron-right"></i>
 				</rl-button-async>
 			</div>

--- a/source/components/messageLog/messageLog.module.ts
+++ b/source/components/messageLog/messageLog.module.ts
@@ -5,6 +5,8 @@ import * as angular from 'angular';
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
 
+import { moduleName as jqueryModuleName } from '../../services/jquery/jquery.service';
+
 import { factoryName, messageLogFactory } from './messageLog.service';
 import { controllerName, directiveName, messageLog, MessageLogController } from './messageLog.directive';
 import {
@@ -19,7 +21,7 @@ export * from './messageLog.directive';
 
 export var moduleName: string = 'rl.ui.components.messageLog';
 
-angular.module(moduleName, [__object.moduleName])
+angular.module(moduleName, [__object.moduleName, jqueryModuleName])
 	.factory(factoryName, messageLogFactory)
 	.directive(directiveName, messageLog)
 	.controller(controllerName, MessageLogController)

--- a/source/components/messageLog/messageLog.module.ts
+++ b/source/components/messageLog/messageLog.module.ts
@@ -16,12 +16,14 @@ import {
 	controllerName as editableMessageLogControllerName
 } from './editableMessageLog';
 
+import { moduleName as templateLoaderModule } from '../../services/templateLoader/templateLoader.service';
+
 export * from './messageLog.service';
 export * from './messageLog.directive';
 
 export var moduleName: string = 'rl.ui.components.messageLog';
 
-angular.module(moduleName, [__object.moduleName, jqueryModuleName])
+angular.module(moduleName, [__object.moduleName, jqueryModuleName, templateLoaderModule])
 	.factory(factoryName, messageLogFactory)
 	.directive(directiveName, messageLog)
 	.controller(controllerName, MessageLogController)

--- a/source/services/templateLoader/templateLoader.service.ts
+++ b/source/services/templateLoader/templateLoader.service.ts
@@ -1,0 +1,68 @@
+/// <reference path='../../../typings/jquery/jquery.d.ts' />
+
+'use strict';
+
+import * as angular from 'angular';
+import * as _ from 'lodash';
+
+import { services } from 'typescript-angular-utilities';
+import __object = services.object;
+
+export var moduleName: string = 'rl.utilities.services.templateLoader';
+export var serviceName: string = 'templateLoader';
+
+export interface TemplateResult {
+	templates: any;
+	default: string;
+	transclusionScope: angular.IScope;
+}
+
+export interface ITemplateLoader {
+	loadTemplates(transclude: angular.ITranscludeFunction): TemplateResult;
+}
+
+class TemplateLoader implements ITemplateLoader {
+	static $inject: string[] = ['$interpolate', 'templateSelectorValue', __object.serviceName];
+	constructor(private $interpolate: angular.IInterpolateService,
+				private templateSelectorValue,
+				private objectUtility: __object.IObjectUtility) { }
+
+	loadTemplates(transclude: angular.ITranscludeFunction): TemplateResult {
+		let result: TemplateResult = {
+			templates: {},
+			default: null,
+			transclusionScope: null,
+		};
+
+		// Load templates from the DOM
+		transclude((clone: angular.IAugmentedJQuery,
+					transclusionScope: angular.IScope): void => {
+			let templates: JQuery = clone.filter(this.templateSelectorValue);
+
+			templates.each((index: number,
+							template: Element): void => {
+				let templateElement: angular.IAugmentedJQuery = angular.element(template);
+				let templateHtml: string = templateElement.html();
+
+				let triggerAttribute: string = templateElement.attr('when-selector');
+				if (!this.objectUtility.isNullOrWhitespace(triggerAttribute)) {
+					let trigger: string = this.$interpolate(triggerAttribute)(transclusionScope);
+					result.templates[trigger] = templateHtml;
+				}
+
+				let isDefault: string = templateElement.attr('default');
+				if (!_.isUndefined(isDefault) && isDefault.toLowerCase() !== 'false') {
+					result.default = templateHtml;
+				}
+			});
+
+			result.transclusionScope = transclusionScope;
+		});
+
+		return result;
+	}
+}
+
+angular.module(moduleName, [__object.moduleName])
+	.value('templateSelectorValue', 'template')
+	.service(serviceName, TemplateLoader);


### PR DESCRIPTION
Now multiple templates can be specified on a message log with a selector to determine which template is used to display each message.
