### PR TITLE
Apply .validation-icon to all icons that are used to show validation …

### DIFF
--- a/source/components/dateTime/dateTime.html
+++ b/source/components/dateTime/dateTime.html
@@ -6,5 +6,5 @@
 			<button class="btn btn-default show-date-picker" ng-click="toggle()"><i class="fa fa-calendar"></i></button>
 		</span>
 	</div>
-	<i class="fa fa-exclamation-triangle text-danger" ng-show="dateTime.ngModel.$error.required"></i>
+	<i class="fa fa-exclamation-triangle text-danger validation-icon" ng-show="dateTime.ngModel.$error.required"></i>
 </div>

--- a/source/components/spinner/spinner.html
+++ b/source/components/spinner/spinner.html
@@ -5,7 +5,7 @@
 			<div class="validation-input" ng-class="{ 'has-error': spinner.ngModel.$invalid }">
 				<input name="{{spinner.name}}" class="spinner" id="{{spinner.spinnerId}}" type="text" />
 			</div>
-			<i class="fa fa-exclamation-triangle text-danger" ng-show="spinner.ngModel.$error.required"></i>
+			<i class="fa fa-exclamation-triangle text-danger validation-icon" ng-show="spinner.ngModel.$error.required"></i>
 		</div>
 	</template>
 	<template when-selector="true">

--- a/source/components/textarea/textarea.html
+++ b/source/components/textarea/textarea.html
@@ -5,5 +5,5 @@
 		</label>
 		<textarea class="form-control" ng-model="textarea.text" name="{{textarea.name}}" rows="{{textarea.rows}}" ng-disabled="textarea.ngDisabled" placeholder="{{textarea.label}}"></textarea>
 	</div>
-	<i class="fa fa-exclamation-triangle text-danger" ng-show="textarea.ngModel.$error.required"></i>
+	<i class="fa fa-exclamation-triangle text-danger validation-icon" ng-show="textarea.ngModel.$error.required"></i>
 </div>

--- a/source/components/textbox/textbox.html
+++ b/source/components/textbox/textbox.html
@@ -5,5 +5,5 @@
 		</label>
 		<input  type="text" class="form-control angular-animate" ng-model="textbox.text" placeholder="{{textbox.label}}"/>
 	</div>
-	<i class="fa fa-exclamation-triangle text-danger" ng-show="textbox.ngModel.$error.required"></i>
+	<i class="fa fa-exclamation-triangle text-danger validation-icon" ng-show="textbox.ngModel.$error.required"></i>
 </div>


### PR DESCRIPTION
…errors. This allows us to focus the styling that positions these immediately to the right of the input to avoid colision with other i tags such as the calendar on the date-time picker.
