### PR TITLE
Fix for generic container

### DIFF
--- a/source/components/genericContainer/genericContainer.ts
+++ b/source/components/genericContainer/genericContainer.ts
@@ -114,7 +114,7 @@ function genericContainer($compile: angular.ICompileService,
 			let container: angular.IAugmentedJQuery = element.find('#container');
 			let templateResult = templateLoader.loadTemplates(transclude);
 
-			controller.templates = templateResult.templates;
+			controller.templates = _.extend(controller.templates, templateResult.templates);
 			controller.default = templateResult.default;
 			let templateScope = templateResult.transclusionScope;
 


### PR DESCRIPTION
Configured templates were getting replaced by templates loaded from the DOM.

Instead we want to merge the templates.
