### PR TITLE
MessageLog: use strong types instead of strings

### DIFF
--- a/source/components/messageLog/editableMessageLog.ts
+++ b/source/components/messageLog/editableMessageLog.ts
@@ -55,7 +55,7 @@ export class EditableMessageLogController {
 		this.savingMessage = true;
 		var message: string = this.newMessage;
 		this.newMessage = '';
-		return this.messageLogService.addMessage(message);
+		return this.messageLogService.addMessage({ message: message });
 	}
 }
 

--- a/source/components/messageLog/messageLog.service.ts
+++ b/source/components/messageLog/messageLog.service.ts
@@ -9,10 +9,10 @@ export var factoryName: string = 'messageLog';
 export var defaultPageSize: number = 10;
 
 export interface IMessage {
+	id?: number;
 	message: string;
 	createdBy?: string,
-	createdDate?: string,
-	createdTime?: string,
+	createdDate?: Date,
 }
 
 export interface IGetMessagesResult {

--- a/source/components/messageLog/messageLog.service.ts
+++ b/source/components/messageLog/messageLog.service.ts
@@ -10,9 +10,9 @@ export var defaultPageSize: number = 10;
 
 export interface IMessage {
 	message: string;
-	createdBy: string,
-	createdDate: string,
-	createdTime: string,
+	createdBy?: string,
+	createdDate?: string,
+	createdTime?: string,
 }
 
 export interface IGetMessagesResult {
@@ -21,12 +21,12 @@ export interface IGetMessagesResult {
 }
 
 export interface IMessageLogDataService {
-	saveMessage(message: string): ng.IPromise<void>;
+	saveMessage(message: IMessage): ng.IPromise<void>;
 	getMessages(startFrom: number, quantity: number): ng.IPromise<IGetMessagesResult>;
 }
 
 export interface IMessageLog {
-	addMessage(message: string): ng.IPromise<void>;
+	addMessage(message: IMessage): ng.IPromise<void>;
 	visibleMessages: IMessage[];
 
 	getNextPage(): ng.IPromise<void>;
@@ -85,7 +85,7 @@ export class MessageLog {
 	}
 	/* tslint:enable */
 
-	addMessage(message: string): ng.IPromise<void> {
+	addMessage(message: IMessage): ng.IPromise<void> {
 		return this.dataService.saveMessage(message).then((): void => {
 			this.getTopPage();
 		});


### PR DESCRIPTION
**Minor version change**

Requires updates to API and consumers in order to use message objects and date objects instead of strings.
