### PR TITLE
Don't wait until the control is dirty to show validation errors. Our …

### DIFF
--- a/source/components/validationGroup/validationGroup.ts
+++ b/source/components/validationGroup/validationGroup.ts
@@ -37,7 +37,6 @@ export class ValidationGroupController {
 					form: $scope.validationGroupForm,
 					$scope: $scope,
 					validators: [this.validator],
-					alwaysValidate: true,
 				});
 			}
 			unbind();

--- a/source/services/componentValidator/componentValidator.service.ts
+++ b/source/services/componentValidator/componentValidator.service.ts
@@ -15,7 +15,6 @@ export interface IComponentValidatorOptions {
 	$scope: angular.IScope;
 	validators: __validation.IValidationHandler[];
 	setValidity?: { (isValid: boolean): void };
-	alwaysValidate?: boolean;
 }
 
 export interface IComponentValidator {
@@ -44,29 +43,7 @@ export class ComponentValidator implements IComponentValidator {
 			this.validator.registerValidationHandler(customValidator);
 		});
 
-		if (options.alwaysValidate) {
-			this.setValidator();
-		} else {
-			let unregisterValidator: Function;
-
-			this.$scope.$watch((): boolean => {
-				return this.isDirty();
-			}, (value: boolean): void => {
-				if (value) {
-					unregisterValidator = this.setValidator();
-				} else {
-					if (_.isFunction(unregisterValidator)) {
-						unregisterValidator();
-					}
-				}
-			});
-		}
-	}
-
-	private isDirty(): boolean {
-		return (_.isUndefined(this.ngModel) && _.isUndefined(this.form))
-				|| (this.ngModel != null && this.ngModel.$dirty)
-				|| (this.form != null && this.form.$dirty);
+		this.setValidator();
 	}
 
 	private setValidator(): Function {


### PR DESCRIPTION
…UX strategy is to guide the users to any issues they need to address from a top down approach, so they'll always be able to see where to find errors that need to be addressed. This is broken if component errors don't show up until the user starts typing.
