### PR TITLE
Should be generic search filter factory name. This is causing the sea…

### DIFF
--- a/source/components/cardContainer/cardContainerBuilder.service.ts
+++ b/source/components/cardContainer/cardContainerBuilder.service.ts
@@ -108,7 +108,7 @@ export class CardContainerBuilder implements ICardContainerBuilder {
 	}
 
 	useSearch(): IGenericSearchFilter {
-		let factory: __genericSearchFilter.IGenericSearchFilterFactory = this.$injector.get<any>(factoryName);
+		let factory: __genericSearchFilter.IGenericSearchFilterFactory = this.$injector.get<any>(__genericSearchFilter.factoryName);
 		this._searchFilter = factory.getInstance();
 		return this._searchFilter;
 	}


### PR DESCRIPTION
…rch to not show up in the card container.
