### PR TITLE
Allow null option

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 			<div ng-controller="TestController as test">
 				Selection: {{test.selection}}
 				<rl-select ng-model="test.selection" options="test.options" option-as="item"
-						   selector="'name'" label="Test selector"></rl-select>
+						   selector="'name'" label="Test selector" null-option="None"></rl-select>
 				<rl-tabset>
 					<rl-tab>
 						<rl-tab-header>Header</rl-tab-header>

--- a/source/components/spinner/spinner.ts
+++ b/source/components/spinner/spinner.ts
@@ -169,6 +169,6 @@ function spinner($timeout: angular.ITimeoutService
 	};
 }
 
-angular.module(moduleName, [__string.moduleName, componentValidatorModuleName])
+angular.module(moduleName, [__string.moduleName, componentValidatorModuleName, __number.moduleName])
 	.directive(directiveName, spinner)
 	.controller(controllerName, SpinnerController);


### PR DESCRIPTION
Added support for specifying a null option for the select dropdown. When a null option is specified, add a config object to the start of the options array. The code will recognize this object and use the nullOption string as its display name, and set ngModel to null when it's selected. This isn't a pretty solution, but it's the only thing I could come up with due to the fact that ui-select doesn't support null-options yet.

Per https://github.com/angular-ui/ui-select/issues/302, null options aren't supported in ui-select yet.

**TODO**: Add unit tests for the select component. This could come in a later PR. I tested this feature visually to make sure that it worked.
