### PR TITLE
Filter group enhancements

### DIFF
--- a/source/components/cardContainer/filters/filterGroup/filterGroup.service.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.service.ts
@@ -16,7 +16,7 @@ export interface IFilterGroupSettings {
 
 export interface IFilterOption extends filters.IFilter {
 	label: string;
-	count: number;
+	count?: number;
 }
 
 export interface IFilterGroup extends filters.IFilterWithCounts {

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.service.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.service.ts
@@ -16,9 +16,12 @@ export interface IFilterGroupSettings {
 
 export interface IFilterOption {
 	label: string;
-	count?: number;
 	type?: string;
 	filter<TItemType>(item: TItemType): boolean;
+}
+
+interface IConfiguredFilterOption extends IFilterOption {
+	count?: number;
 }
 
 export interface IFilterGroup extends filters.IFilterWithCounts {
@@ -62,7 +65,7 @@ export class FilterGroup implements IFilterGroup {
 	}
 
 	setOptionCounts(counts: number[]): void {
-		_.each(this.options, (option: IFilterOption): void => {
+		_.each(this.options, (option: IConfiguredFilterOption): void => {
 			if (_.has(counts, option.type)) {
 				option.count = counts[option.type];
 			}
@@ -70,7 +73,7 @@ export class FilterGroup implements IFilterGroup {
 	}
 
 	updateOptionCounts<TDataType>(filteredDataSet: TDataType[]): void {
-		_.each(this.options, (option: IFilterOption): void => {
+		_.each(this.options, (option: IConfiguredFilterOption): void => {
 			option.count = _.filter(filteredDataSet, option.filter, option).length;
 		});
 	}

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.service.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.service.ts
@@ -14,9 +14,11 @@ export interface IFilterGroupSettings {
 	options: IFilterOption[];
 }
 
-export interface IFilterOption extends filters.IFilter {
+export interface IFilterOption {
 	label: string;
 	count?: number;
+	type?: string;
+	filter<TItemType>(item: TItemType): boolean;
 }
 
 export interface IFilterGroup extends filters.IFilterWithCounts {


### PR DESCRIPTION
Hide count from the IFilterOption interface. This is an internal implementation detail for the filter group. Also make type optional. If not specified, the label is used as the type.

Should probably be a minor version, as this will be a breaking change for @TheOriginalJosh 
