### PR TITLE
Created default styling against the busy component to show a font-awe…

### DIFF
--- a/source/components/busy/busy.css
+++ b/source/components/busy/busy.css
@@ -1,0 +1,12 @@
+.busy {
+	-webkit-animation: fa-spin 2s infinite linear;
+	animation: fa-spin 2s infinite linear;
+	display: inline-block;
+	font-size: inherit;
+	font-style: normal;
+	font-family: FontAwesome;
+}
+
+.busy:before {
+	content: "\f110"; /* fa-spinner */
+}

--- a/source/components/busy/busy.ts
+++ b/source/components/busy/busy.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import './busy.css';
+
 import * as angular from 'angular';
 
 export var moduleName: string = 'rl.ui.components.busy';


### PR DESCRIPTION
…some busy spinner. Most of this is the same styling that gets applied by `fa fa-spinner fa-spin`. This allows consumers to overwrite it if they want to use a different spinner.

left - font awesome, right - custom:
![image](https://cloud.githubusercontent.com/assets/6878589/12025235/7943a854-ad7a-11e5-9e60-7cacf2e3b3e8.png)
