### PR TITLE
Allow message data to be put on the scope

### DIFF
--- a/source/components/messageLog/messageLog.directive.ts
+++ b/source/components/messageLog/messageLog.directive.ts
@@ -100,11 +100,6 @@ export class MessageLogController implements IMessageLogBindings {
 	}
 }
 
-interface IMessageLogScope {
-	defaultTemplate: IGenericTemplate | string;
-
-}
-
 messageLog.$inject = [
 	'$interpolate',
 	jqueryServiceName,
@@ -122,7 +117,9 @@ export function messageLog($interpolate: angular.IInterpolateService,
 		transclude: true,
 		controller: controllerName,
 		controllerAs: 'log',
-		scope: {},
+		scope: {
+			messageData: "=",
+		},
 		bindToController: {
 			service: '=',
 			selector: '=',


### PR DESCRIPTION
This lets templates access stuff from the parent scope. This is a hack, but is the only easy way to pass stuff from outer parent scopes through to the message scope.
