### PR TITLE
Fix generic container

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 
 		<script src="/node_modules/jquery/dist/jquery.js"></script>
 		<script src="/node_modules/angular/angular.js"></script>
+		<script src="/node_modules/angular-animate/angular-animate.js"></script>
 		<script src="/node_modules/lodash/index.js"></script>
 		<script src="/node_modules/moment/moment.js"></script>
 		<script src="/node_modules/typescript-angular-utilities/output/utilities.js"></script>
@@ -19,6 +20,17 @@
 
 		<div ng-app="app">
 			<div ng-controller="TestController as test">
+				<rl-checkbox ng-model="test.toggle">Toggle</rl-checkbox>
+				<ng-form name="myTestForm">
+					<i class="fa fa-flash" ng-show="myTestForm.$dirty"></i>
+					<input type="text" ng-model="test.string" />
+					Container 1
+					<rl-generic-container selector="test.toggle">
+						<template default><input type="text" ng-model="test.string" /></template>
+						<template when-selector="true"><div>{{test.string}}</div></template>
+					</rl-generic-container>
+				</ng-form>
+
 				Selection: {{test.selection}}
 				<rl-select ng-model="test.selection" options="test.options" option-as="item"
 						   selector="'name'" label="Test selector" null-option="None"></rl-select>

--- a/source/components/genericContainer/genericContainer.ts
+++ b/source/components/genericContainer/genericContainer.ts
@@ -32,12 +32,12 @@ export class GenericContainerController {
 	// Attribute bindings:
 	selector: any;
 	configuredTemplates: any;
-	defaultTemplate: IGenericTemplate | string;
+	defaultTemplate: JQuery;
 
 	// Link / controller coupling
 	templates: any;
-	default: IGenericTemplate | string;
-	swapTemplates: {(template: string): void};
+	default: JQuery;
+	swapTemplates: {(template: JQuery): void};
 
 	static $inject: string[] = ['$scope', __object.serviceName];
 	constructor($scope: angular.IScope,
@@ -47,33 +47,21 @@ export class GenericContainerController {
 				return;
 			}
 
-			var template: string = this.resolveTemplate(newType);
+			var template: JQuery = this.resolveTemplate(newType);
 			this.swapTemplates(template);
 		});
 	}
 
 	refresh(): void {
-		var template: string = this.resolveTemplate(this.selector);
+		var template: JQuery = this.resolveTemplate(this.selector);
 		this.swapTemplates(template);
 	}
 
-	resolveTemplate(type: string): string {
-		var templateObject: IGenericTemplate | string;
-
+	resolveTemplate(type: string): JQuery {
 		if (_.has(this.templates, type)) {
-			templateObject = this.templates[type];
+			return this.templates[type];
 		} else {
-			templateObject = this.default;
-		}
-
-		var template: IGenericTemplate = templateObject;
-
-		if (!_.isUndefined(template.templateUrl)) {
-			return '<ng-include src="\'' + template.templateUrl + '\'"></ng-include>';
-		} else if (!_.isUndefined(template.template)) {
-			return template.template;
-		} else {
-			return <string> templateObject;
+			return this.default;
 		}
 	}
 }
@@ -119,9 +107,7 @@ function genericContainer($compile: angular.ICompileService,
 			let templateScope = templateResult.transclusionScope;
 
 			if (!controller.default) {
-				controller.default = {
-					template: '<div></div>',
-				};
+				controller.default = angular.element('<div></div>');
 			}
 
 			controller.refresh();
@@ -132,9 +118,9 @@ function genericContainer($compile: angular.ICompileService,
 				controller.swapTemplates = swapTemplates;
 			}
 
-			function swapTemplates(template: string): void {
+			function swapTemplates(template: JQuery): void {
+				jquery.replaceContent(container, template);
 				let content: angular.IAugmentedJQuery = $compile(template)(templateScope);
-				jquery.replaceContent(container, content);
 			}
 		}
 	};

--- a/source/services/templateLoader/templateLoader.service.ts
+++ b/source/services/templateLoader/templateLoader.service.ts
@@ -12,7 +12,7 @@ export var moduleName: string = 'rl.utilities.services.templateLoader';
 export var serviceName: string = 'templateLoader';
 
 export interface TemplateResult {
-	templates: any;
+	templates: { [index: string]: JQuery };
 	default: JQuery;
 	transclusionScope: angular.IScope;
 }

--- a/source/services/templateLoader/templateLoader.service.ts
+++ b/source/services/templateLoader/templateLoader.service.ts
@@ -13,7 +13,7 @@ export var serviceName: string = 'templateLoader';
 
 export interface TemplateResult {
 	templates: any;
-	default: string;
+	default: JQuery;
 	transclusionScope: angular.IScope;
 }
 
@@ -43,16 +43,17 @@ class TemplateLoader implements ITemplateLoader {
 							template: Element): void => {
 				let templateElement: angular.IAugmentedJQuery = angular.element(template);
 				let templateHtml: string = templateElement.html();
+				let childElement: angular.IAugmentedJQuery = angular.element(templateHtml);
 
 				let triggerAttribute: string = templateElement.attr('when-selector');
 				if (!this.objectUtility.isNullOrWhitespace(triggerAttribute)) {
 					let trigger: string = this.$interpolate(triggerAttribute)(transclusionScope);
-					result.templates[trigger] = templateHtml;
+					result.templates[trigger] = childElement;
 				}
 
 				let isDefault: string = templateElement.attr('default');
 				if (!_.isUndefined(isDefault) && isDefault.toLowerCase() !== 'false') {
-					result.default = templateHtml;
+					result.default = childElement;
 				}
 			});
 


### PR DESCRIPTION
After some investigation, I determined that any new elements need to be added to the parent _before_ they are compiled for them to be able to correctly access the parent context. For the generic container, that means that we need to resolve the templates to JQuery objects in the template loader. Then in the swap templates function, we can replace the container content with the template element, and then compile it. This also means we'll need to map code-generated templates to JQuery elements on init.

Stack overflow: http://stackoverflow.com/a/27645175/4220059
