### PR TITLE
If the result is not a promise, hide the spinner unless the action re…

### DIFF
--- a/source/components/buttonAsync/buttonAsync.ts
+++ b/source/components/buttonAsync/buttonAsync.ts
@@ -45,6 +45,8 @@ export class ButtonAsyncController {
 				result.finally((): void => {
 					this.busy = false;
 				});
+			} else if (<any>result !== true) {
+				this.busy = false;
 			}
 		}
 	}


### PR DESCRIPTION
…turns true. (Essentially, the action needs to return true to specify that a spinner should be shown)
