### PR TITLE
Columns removing inline style

### DIFF
--- a/source/components/cardContainer/card/headerColumn/headerColumn.ts
+++ b/source/components/cardContainer/card/headerColumn/headerColumn.ts
@@ -40,7 +40,7 @@ export function headerColumn($compile: angular.ICompileService): angular.IDirect
 		restrict: 'E',
 		template: `
 			<div rl-size-for-breakpoints="header.column.size" title="{{::header.column.description}}">
-				<div class="template-container" style="display: inline-block"></div>
+				<div class="template-container"></div>
 			</div>
 		`,
 		controller: controllerName,

--- a/source/components/cardContainer/columnHeader/columnHeader.ts
+++ b/source/components/cardContainer/columnHeader/columnHeader.ts
@@ -28,7 +28,7 @@ export function cardColumnHeader($compile: angular.ICompileService): angular.IDi
 		template: `
 			<div rl-size-for-breakpoints="column.size" ng-click="sort()" title="{{::column.description}}"
 					class="column-header">
-				<div class="template-container" style="display: inline-block"></div>
+				<div class="template-container"></div>
 				<i ng-show="sorting === sortDirection.ascending" class="fa fa-sort-asc"></i>
 				<i ng-show="sorting === sortDirection.descending" class="fa fa-sort-desc"></i>
 			</div>


### PR DESCRIPTION
Moving inline style from component to Theme project. The style will be applied to `.template-container` instead of being an inline style.

https://github.com/RenovoSolutions/RenovoTheme/pull/84
