### PR TITLE
Message Log - Layout Fixes for Remove Button [Markup]

### DIFF
--- a/source/components/messageLog/messageLog.html
+++ b/source/components/messageLog/messageLog.html
@@ -3,13 +3,18 @@
 	<div class="content-group" ng-repeat="entry in log.messages" rl-alias="entry as {{log.messageAs}}">
 		<rl-generic-container selector="log.getEntrySelector(entry)" templates="log.templates">
 			<template default>
-				<div ng-bind-html="entry.message"></div>
-				<span ng-if="log.canDeleteEntry(entry)">
-					<rl-button-async class="pull-right" action="log.messageLog.deleteMessage(entry)" size="sm"><i class="fa fa-remove"></i></rl-button-async>
-					<div class="clearfix"></div>
-				</span>
-				<div class="byline">{{entry.createdBy.name}}</div>
-				<div class="byline">{{entry.createdDate | date:'short'}} UTC</div>
+				<div class="message-body">
+					<div class="message-content">
+						<div ng-bind-html="entry.message"></div>
+					</div>
+					<span class="message-delete" ng-if="log.canDeleteEntry(entry)">
+						<rl-button-async type="danger" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
+					</span>
+				</div>
+				<div class="message-byline">
+					<div class="byline">{{entry.createdBy.name}}</div>
+					<div class="byline">{{entry.createdDate | date:'short'}} UTC</div>
+				</div>
 			</template>
 		</rl-generic-container>
 	</div>

--- a/source/components/messageLog/messageLog.html
+++ b/source/components/messageLog/messageLog.html
@@ -8,7 +8,7 @@
 						<div ng-bind-html="entry.message"></div>
 					</div>
 					<span class="message-delete" ng-if="log.canDeleteEntry(entry)">
-						<rl-button-async type="danger" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
+						<rl-button-async type="danger flat" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
 					</span>
 				</div>
 				<div class="message-byline">

--- a/source/components/messageLog/messageLog.html
+++ b/source/components/messageLog/messageLog.html
@@ -7,8 +7,8 @@
 					<div class="message-content">
 						<div ng-bind-html="entry.message"></div>
 					</div>
-					<span class="message-delete" ng-if="log.canDeleteEntry(entry)">
-						<rl-button-async type="danger flat" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
+					<span class="message-button" ng-if="log.canDeleteEntry(entry)">
+						<rl-button-async type="message-delete-button flat" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
 					</span>
 				</div>
 				<div class="message-byline">


### PR DESCRIPTION
# Message Log - Layout Fixes for Remove Button [Markup]

This PR goes along with [RenovoTheme PR #108](https://github.com/RenovoSolutions/RenovoTheme/pull/108). This will break a message log message down into pieces that can be styled against. We can place the 'remove' button properly without any kind of overlapping in elements.

![msg-log-delete-gray](https://cloud.githubusercontent.com/assets/13574057/13093160/b6eba610-d4d1-11e5-9e35-83c51c7e0c06.PNG)
