### PR TITLE
Exclude angular-ui from the bundle

### DIFF
--- a/webpack.library.json
+++ b/webpack.library.json
@@ -5,6 +5,7 @@
 	"library": "rl_components",
 	"externals": {
 		"angular": "angular",
+		"angular-ui-bootstrap": "angular-ui",
 		"jquery": "$",
 		"moment": "moment",
 		"lodash": "_",


### PR DESCRIPTION
Requires minor version change. This is a breaking change. Consumers will now need to include angular-ui manually.
