### PR TITLE
Message Log Fixes

### DIFF
--- a/source/components/messageLog/messageLog.html
+++ b/source/components/messageLog/messageLog.html
@@ -8,7 +8,7 @@
 						<div ng-bind-html="entry.message"></div>
 					</div>
 					<span class="message-button" ng-if="log.canDeleteEntry(entry)">
-						<rl-button-async type="message-delete-button flat" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
+						<rl-button-async type="message-delete flat" action="log.messageLog.deleteMessage(entry)" size="xs"><i class="fa fa-remove"></i></rl-button-async>
 					</span>
 				</div>
 				<div class="message-byline">

--- a/source/components/messageLog/messageLog.html
+++ b/source/components/messageLog/messageLog.html
@@ -1,6 +1,6 @@
 <div>
 	<rl-busy loading="log.loadingInitial" size="2x"></rl-busy>
-	<div class="content-group" ng-repeat="entry in log.messages" rl-alias="entry as {{log.messageAs}}">
+	<div class="content-group" ng-repeat="entry in log.messages" rl-alias="entry as {{log.messageAs}}" ng-class="{ 'system-note': entry.isSystemNote }">
 		<rl-generic-container selector="log.getEntrySelector(entry)" templates="log.templates">
 			<template default>
 				<div class="message-body">


### PR DESCRIPTION
- Changed **button type** to match changes being made in the Theme. It doesn't work how it is right now anyway since `btn-` is added to the front, making it `btn-message-delete-button`.
- Added a ng-class to apply a `.system-note` class. This means we can style system notes and user notes differently.

Grabs styling from [RenovoTheme PR #113](https://github.com/RenovoSolutions/RenovoTheme/pull/113)
