### PR TITLE
Adding .field & changing group error class name

### DIFF
--- a/source/components/dateTime/dateTime.html
+++ b/source/components/dateTime/dateTime.html
@@ -1,4 +1,4 @@
-<div class="input-group" ng-class="{ 'has-warning': !dateTime.validFormat, 'error': dateTime.ngModel.$invalid }">
+<div class="input-group field" ng-class="{ 'has-warning': !dateTime.validFormat, 'error': dateTime.ngModel.$invalid }">
 	<span class="show-date-picker">
 		<input type="text" class="form-control" ng-model="dateTime.ngModel.$viewValue" />
 		<span class="input-group-btn">

--- a/source/components/spinner/spinner.html
+++ b/source/components/spinner/spinner.html
@@ -1,6 +1,6 @@
 <rl-generic-container selector="spinner.ngDisabled">
 	<template default>
-		<div ng-class="{ 'error': spinner.ngModel.$invalid }">
+		<div class="field" ng-class="{ 'error': spinner.ngModel.$invalid }">
 			<input name="{{spinner.name}}" class="spinner" id="{{spinner.spinnerId}}" type="text" />
 			<span class="error-string" ng-hide="spinner.spinnerValidator.error | isEmpty">{{spinner.spinnerValidator.error}}</span>
 		</div>

--- a/source/components/spinner/spinner.html
+++ b/source/components/spinner/spinner.html
@@ -6,20 +6,20 @@
 		</div>
 	</template>
 	<template when-selector="true">
-		<div class="input-group" ng-show="spinner.prefix != null && spinner.postfix != null">
+		<div class="input-group field" ng-show="spinner.prefix != null && spinner.postfix != null">
 			<span class="input-group-addon">{{spinner.prefix}}</span>
 			<input disabled="true" type="text" ng-model="spinner.ngModel.$viewValue" class="form-control" />
 			<span class="input-group-addon">{{spinner.postfix}}</span>
 		</div>
-		<div class="input-group" ng-show="spinner.prefix != null && spinner.postfix == null">
+		<div class="input-group field" ng-show="spinner.prefix != null && spinner.postfix == null">
 			<span class="input-group-addon">{{spinner.prefix}}</span>
 			<input disabled="true" type="text" ng-model="spinner.ngModel.$viewValue" class="form-control" />
 		</div>
-		<div class="input-group" ng-show="spinner.prefix == null && spinner.postfix != null">
+		<div class="input-group field" ng-show="spinner.prefix == null && spinner.postfix != null">
 			<input disabled="true" type="text" ng-model="spinner.ngModel.$viewValue" class="form-control" />
 			<span class="input-group-addon">{{spinner.postfix}}</span>
 		</div>
-		<div class="input-group" ng-show="spinner.prefix == null && spinner.postfix == null">
+		<div class="input-group field" ng-show="spinner.prefix == null && spinner.postfix == null">
 			<input disabled="true" type="text" ng-model="spinner.ngModel.$viewValue" class="form-control" />
 		</div>
 	</template>

--- a/source/components/validationGroup/validationGroup.html
+++ b/source/components/validationGroup/validationGroup.html
@@ -1,5 +1,5 @@
 <div class="content-group" ng-form="validationGroupForm">
-	<div class="error" ng-show="validationGroupForm.$error.customValidation">
+	<div class="error-message" ng-show="validationGroupForm.$error.customValidation">
 		<label>{{group.groupValidator.error}}</label>
 	</div>
 	<div ng-transclude></div>


### PR DESCRIPTION
Added `.field` to our **dateTime** and **spinner** components.
- Will need some small fixes in the Theme.

I also changed `content-group` error messages to use the class name `.error-message` instead of just `.error`. This will make sure their styling is scoped better and not overwriting other element's classes.
- This change will require a Theme PR to change styling from `.error` to `.error-message`. Should just be an easy name switch.
#### This will all still work - just ugly without theme updates.

https://github.com/RenovoSolutions/RenovoTheme/pull/124
