### PR TITLE
Added ng-class to datepicker for when it has a clear button.

### DIFF
--- a/source/components/dateTime/dateTime.html
+++ b/source/components/dateTime/dateTime.html
@@ -1,11 +1,11 @@
-<div class="input-group field" ng-class="{ 'has-warning': !dateTime.validFormat, 'error': dateTime.ngModel.$invalid }">
+<div class="input-group field" ng-class="{ 'has-warning': !dateTime.validFormat, 'error': dateTime.ngModel.$invalid, 'datepicker-with-clear': dateTime.clearButton }">
 	<span class="show-date-picker">
 		<input type="text" class="form-control" ng-model="dateTime.ngModel.$viewValue" />
 		<span class="input-group-btn">
 			<button class="btn btn-default" ng-click="toggle()"><i class="fa fa-calendar"></i></button>
 		</span>
 	</span>
-	<span class="input-group-btn" ng-if="::dateTime.clearButton">
+	<span class="input-group-btn" ng-if="::dateTime.clearButton" ng-class="::{ 'btn-date-clear':dateTime.clearButton }">
 		<button type="button" class="btn btn-default pull-left"  ng-disabled="dateTime.ngModel.$viewValue | isEmpty" ng-click="dateTime.onClearClick()" >
 			<i class="fa fa-times"></i>
 		</button>


### PR DESCRIPTION
Paired with @TheOriginalJosh 

This will allow us to properly style the datepicker when it's using a clear button.

Currently looks like this:

![datepicker-w-clear](https://cloud.githubusercontent.com/assets/13574057/14031768/c669e324-f1e4-11e5-8b47-612e00da3958.PNG)
