### PR TITLE
Typeahead list fixes

### DIFF
--- a/bootstrapper/bootstrapApp.ts
+++ b/bootstrapper/bootstrapApp.ts
@@ -1,3 +1,5 @@
+import * as angular from 'angular';
+
 import { moduleName as componentsModule } from '../source/ui.module';
 
 const inputsTemplate = require('./inputs/inputs.html');

--- a/bootstrapper/inputs/inputBootstrapper.ts
+++ b/bootstrapper/inputs/inputBootstrapper.ts
@@ -14,6 +14,7 @@ class InputTestController {
 	set: ITestItem[];
 	options: ITestItem[];
 	typeaheadList: ITestItem[];
+	useSearch: boolean;
 	date: moment.Moment;
 	date2: moment.Moment;
 	validate1: number;
@@ -35,6 +36,7 @@ class InputTestController {
 		];
 
 		this.typeaheadList = [this.options[0], this.options[4]];
+		this.useSearch = true;
 
 		this.date = moment('2016-04-01T12:00:00.000-08:00').tz('US/Pacific');
 		__timezone.timezoneService.setCurrentTimezone('-08:00');

--- a/bootstrapper/inputs/inputs.html
+++ b/bootstrapper/inputs/inputs.html
@@ -64,8 +64,9 @@
 
 <div>
 	<label>Typeahead list:</label>
+	<rl-checkbox ng-model="input.useSearch">Toggle search</rl-checkbox>
 	<rl-typeahead-list get-items="input.getOptions()" ng-model="input.typeaheadList" transform="'name'"
-						label="Test list">
+						label="Test list" disable-searching="!input.useSearch">
 		<rl-list-header><div class="col-xs-12">Test list</div></rl-list-header>
 		<rl-list-item>
 				<div class="col-xs-10">{{$item.name}}</div>

--- a/source/components/dateTime/dateTime.md
+++ b/source/components/dateTime/dateTime.md
@@ -35,6 +35,10 @@ If set to true, shows a button for clearing the date-time value.
 
 This expression will be triggered whenever the clear button is clicked, if clear is enabled.
 
+`ng-model`, `validator`, `validators`, `label`, `name`.
+
+See [input](../input/input.md) for detail on the base options.
+
 ### Full example
 A date picker with **clear-button**.
 ```

--- a/source/components/genericContainer/genericContainer.ts
+++ b/source/components/genericContainer/genericContainer.ts
@@ -54,7 +54,7 @@ export class GenericContainerController {
 			, private templateLoader: ITemplateLoader) {}
 
 	$onChanges(changes: IGenericContainerChanges): void {
-		if (changes.selector) {
+		if (this.container && changes.selector) {
 			let template: string = this.resolveTemplate(changes.selector.currentValue);
 			this.swapTemplates(template);
 		}

--- a/source/components/select/select.md
+++ b/source/components/select/select.md
@@ -29,4 +29,6 @@ This option will set `disabled` on the textarea if the [expression](https://docs
 
 Example: `ng-disabled="true"` will output `<textarea disabled> ... </textarea>`
 
+`ng-model`, `validator`, `validators`, `label`, `name`.
+
 See [input](../input/input.md) for detail on the base options.

--- a/source/components/select/select.md
+++ b/source/components/select/select.md
@@ -23,6 +23,10 @@ A selector for getting the display name of the options. Can be a property name o
 
 If specified, will show an option with the specified text at the top of the list for 'clearing' the selection.
 
+#### `select`
+
+This expression will be triggered whenever a selection is made in the dropdown.
+
 #### [`ng-disabled`](https://docs.angularjs.org/api/ng/directive/ngDisabled)
 
 This option will set `disabled` on the textarea if the [expression](https://docs.angularjs.org/guide/expression) inside it is truthy.

--- a/source/components/select/select.ts
+++ b/source/components/select/select.ts
@@ -15,9 +15,13 @@ import __transform = services.transform.transform;
 import { buildInput, InputController, moduleName as inputModule } from '../input/input';
 import { IComponentValidatorFactory, factoryName as componentValidatorFactoryName } from '../../services/componentValidator/componentValidator.service';
 
-export var moduleName: string = 'rl.ui.components.select';
-export var componentName: string = 'rlSelect';
-export var controllerName: string = 'SelectController';
+export const moduleName: string = 'rl.ui.components.select';
+export const componentName: string = 'rlSelect';
+export const controllerName: string = 'SelectController';
+
+export interface ISelectParams {
+	item: any;
+}
 
 export class SelectController extends InputController {
 	// bindings
@@ -26,6 +30,7 @@ export class SelectController extends InputController {
 	selector: { (item: any): string } | string;
 	ngDisabled: boolean;
 	nullOption: string;
+	select: { (params: ISelectParams): void };
 
 	loading: boolean;
 
@@ -43,6 +48,7 @@ export class SelectController extends InputController {
 		} else {
 			this.ngModel.$setViewValue(value);
 		}
+		this.select(this.ngModel.$viewValue);
 	}
 
 	static $inject: string[] = ['$scope', '$attrs', '$q', __object.serviceName, componentValidatorFactoryName];
@@ -95,7 +101,7 @@ export class SelectController extends InputController {
 	}
 }
 
-let select: angular.IComponentOptions = buildInput({
+const select: angular.IComponentOptions = buildInput({
 	template: require('./select.html'),
 	controller: controllerName,
 	controllerAs: 'select',
@@ -105,6 +111,7 @@ let select: angular.IComponentOptions = buildInput({
 		selector: '<?',
 		ngDisabled: '<?',
 		nullOption: '@',
+		select: '&',
 	},
 });
 

--- a/source/components/select/select.ts
+++ b/source/components/select/select.ts
@@ -48,7 +48,7 @@ export class SelectController extends InputController {
 		} else {
 			this.ngModel.$setViewValue(value);
 		}
-		this.select(this.ngModel.$viewValue);
+		this.select({ item: this.ngModel.$viewValue });
 	}
 
 	static $inject: string[] = ['$scope', '$attrs', '$q', __object.serviceName, componentValidatorFactoryName];

--- a/source/components/spinner/spinner.md
+++ b/source/components/spinner/spinner.md
@@ -41,6 +41,8 @@ This option will set `disabled` on the textarea if the [expression](https://docs
 
 Example: `ng-disabled="true"` will output `<textarea disabled> ... </textarea>`
 
+`ng-model`, `validator`, `validators`, `label`, `name`.
+
 See [input](../input/input.md) for detail on the base options.
 
 #### `spinner-id`

--- a/source/components/textarea/textarea.md
+++ b/source/components/textarea/textarea.md
@@ -21,6 +21,8 @@ This option will set `disabled` on the textarea if the [expression](https://docs
 
 Example: `ng-disabled="true"` will output `<textarea disabled> ... </textarea>`
 
+`ng-model`, `validator`, `validators`, `label`, `name`.
+
 See [input](../input/input.md) for detail on the base options.
 
 ### Full example

--- a/source/components/textbox/textbox.md
+++ b/source/components/textbox/textbox.md
@@ -11,6 +11,8 @@ This component extends the base [input](../input/input.md) with textbox-specific
 
 Sets the maxlength of the textbox.
 
+`ng-model`, `validator`, `validators`, `label`, `name`.
+
 See [input](../input/input.md) for detail on the base options.
 
 ### Full example

--- a/source/components/typeahead/typeahead.md
+++ b/source/components/typeahead/typeahead.md
@@ -43,4 +43,6 @@ This option will set `disabled` on the textarea if the [expression](https://docs
 
 Example: `ng-disabled="true"` will output `<textarea disabled> ... </textarea>`
 
+`ng-model`, `validator`, `validators`, `label`, `name`.
+
 See [input](../input/input.md) for detail on the base options.

--- a/source/components/typeaheadList/typeaheadList.html
+++ b/source/components/typeaheadList/typeaheadList.html
@@ -1,6 +1,6 @@
 <rl-typeahead ng-model="list.model" select="list.addItem(value)" allow-collapse="false" child-link="list.typeaheadLink"
-			  transform="list.transform" get-items="list.loadItems(search)" label="{{list.label}}"
-			  prefix="{{list.prefix}}" use-client-searching="list.useClientSearching" ng-disabled="list.ngDisabled"></rl-typeahead>
+			  transform="list.transform" get-items="list.searchItems(search)" label="{{list.label}}"
+			  prefix="{{list.prefix}}" ng-disabled="list.ngDisabled"></rl-typeahead>
 <div class="table-container col-xs-12">
 	<div class="row table-header" ng-show="list.ngModel.$viewValue | isEmpty:false">
 		<div ng-transclude="headerSlot">

--- a/source/components/typeaheadList/typeaheadList.html
+++ b/source/components/typeaheadList/typeaheadList.html
@@ -1,6 +1,14 @@
-<rl-typeahead ng-model="list.model" select="list.addItem(value)" allow-collapse="false" child-link="list.typeaheadLink"
-			  transform="list.transform" get-items="list.searchItems(search)" label="{{list.label}}"
-			  prefix="{{list.prefix}}" ng-disabled="list.ngDisabled"></rl-typeahead>
+<rl-generic-container selector="list.disableSearching">
+	<template when-selector="true">
+		<rl-select ng-model="list.model" select="list.addItem(item)" selector="list.transform"
+				   options="list.cachedItems" label="{{list.label}}" ng-disabled="list.ngDisabled"></rl-select>
+	</template>
+	<template default>
+		<rl-typeahead ng-model="list.model" select="list.addItem(value)" allow-collapse="false"
+					  transform="list.transform" get-items="list.searchItems(search)" label="{{list.label}}"
+					  prefix="{{list.prefix}}" ng-disabled="list.ngDisabled"></rl-typeahead>
+	</template>
+</rl-generic-container>
 <div class="table-container col-xs-12">
 	<div class="row table-header" ng-show="list.ngModel.$viewValue | isEmpty:false">
 		<div ng-transclude="headerSlot">

--- a/source/components/typeaheadList/typeaheadList.html
+++ b/source/components/typeaheadList/typeaheadList.html
@@ -2,7 +2,7 @@
 			  transform="list.transform" get-items="list.loadItems(search)" label="{{list.label}}"
 			  prefix="{{list.prefix}}" use-client-searching="list.useClientSearching" ng-disabled="list.ngDisabled"></rl-typeahead>
 <div class="table-container col-xs-12">
-	<div class="row table-header">
+	<div class="row table-header" ng-show="list.ngModel.$viewValue | isEmpty:false">
 		<div ng-transclude="headerSlot">
 			<div class="col-xs-12">Name</div>
 		</div>

--- a/source/components/typeaheadList/typeaheadList.tests.ts
+++ b/source/components/typeaheadList/typeaheadList.tests.ts
@@ -77,10 +77,23 @@ describe('TypeaheadListController', () => {
 
 				typeaheadList.searchItems('2');
 
-				scope.$digest();
-
 				sinon.assert.notCalled(getItemsSpy);
 			});
+
+		it('should load the items when searching is disabled', (): void => {
+			buildController();
+			let getItemsSpy: Sinon.SinonSpy = sinon.spy((): angular.IPromise<ITestObject[]> => { return $q.when(items); });
+			typeaheadList.getItems = getItemsSpy;
+			typeaheadList.$onChanges({
+				disableSearching: <any>{ currentValue: true },
+			});
+
+			sinon.assert.calledOnce(getItemsSpy);
+
+			scope.$digest();
+
+			expect(typeaheadList.cachedItems).to.not.be.empty;
+		});
 	});
 
 	describe('add', (): void => {

--- a/source/components/typeaheadList/typeaheadList.tests.ts
+++ b/source/components/typeaheadList/typeaheadList.tests.ts
@@ -94,6 +94,20 @@ describe('TypeaheadListController', () => {
 
 			expect(typeaheadList.cachedItems).to.not.be.empty;
 		});
+
+		it('should load the items on init if searching is disabled', (): void => {
+			buildControllerWithoutInit();
+			let getItemsSpy: Sinon.SinonSpy = sinon.spy((): angular.IPromise<ITestObject[]> => { return $q.when(items); });
+			typeaheadList.getItems = getItemsSpy;
+			typeaheadList.disableSearching = true;
+			typeaheadList.$onInit();
+
+			sinon.assert.calledOnce(getItemsSpy);
+
+			scope.$digest();
+
+			expect(typeaheadList.cachedItems).to.not.be.empty;
+		});
 	});
 
 	describe('add', (): void => {
@@ -167,7 +181,7 @@ describe('TypeaheadListController', () => {
 		});
 	});
 
-	function buildController(list?: ITestObject[]): void {
+	function buildControllerWithoutInit(list?: ITestObject[]): void {
 		let ngModel: any = {
 			$viewValue: list,
 			$setViewValue: (value: any): void => { ngModel.$viewValue = value; },
@@ -193,6 +207,10 @@ describe('TypeaheadListController', () => {
 			return $q.when(items);
 		});
 		typeaheadList.useClientSearching = true;
+	}
+
+	function buildController(list?: ITestObject[]): void {
+		buildControllerWithoutInit(list);
 		typeaheadList.$onInit();
 	}
 });

--- a/source/components/typeaheadList/typeaheadList.ts
+++ b/source/components/typeaheadList/typeaheadList.ts
@@ -144,13 +144,14 @@ export class TypeaheadListController implements ITypeaheadListBindings {
 			add: this.addItem.bind(this),
 			remove: this.removeItem.bind(this),
 		});
+		if (this.disableSearching) {
+			this.loadCachedItems();
+		}
 	}
 
 	$onChanges(changes: ITypeaheadListChanges): void {
 		if (changes.disableSearching && changes.disableSearching.currentValue && !this.cachedItems) {
-			this.searchItems().then((items: any[]): void => {
-				this.cachedItems = items;
-			});
+			this.loadCachedItems();
 		}
 	}
 
@@ -206,6 +207,12 @@ export class TypeaheadListController implements ITypeaheadListBindings {
 		} else {
 			return filteredList;
 		}
+	}
+
+	private loadCachedItems(): void {
+		this.searchItems().then((items: any[]): void => {
+			this.cachedItems = items;
+		});
 	}
 }
 

--- a/source/components/typeaheadList/typeaheadList.ts
+++ b/source/components/typeaheadList/typeaheadList.ts
@@ -147,7 +147,7 @@ export class TypeaheadListController implements ITypeaheadListBindings {
 	}
 
 	$onChanges(changes: ITypeaheadListChanges): void {
-		if (changes.disableSearching && changes.disableSearching.currentValue) {
+		if (changes.disableSearching && changes.disableSearching.currentValue && !this.cachedItems) {
 			this.searchItems().then((items: any[]): void => {
 				this.cachedItems = items;
 			});

--- a/source/components/typeaheadList/typeaheadList.ts
+++ b/source/components/typeaheadList/typeaheadList.ts
@@ -143,6 +143,7 @@ export class TypeaheadListController implements ITypeaheadListBindings {
 		return this.$q.when(this.add({ item: item })).then((newItem: any): void => {
 			newItem = newItem || item;
 			this.ngModel.$viewValue.push(newItem);
+			this.ngModel.$setDirty();
 			this.parentChild.triggerChildBehavior(this.typeaheadLink, (behavior: ITypeaheadBehavior): void => {
 				behavior.remove(newItem);
 			});
@@ -153,6 +154,7 @@ export class TypeaheadListController implements ITypeaheadListBindings {
 	removeItem(item: any): angular.IPromise<void> {
 		return this.$q.when(this.remove({ item: item })).then((): void => {
 			__array.arrayUtility.remove(this.ngModel.$viewValue, item);
+			this.ngModel.$setDirty();
 			this.parentChild.triggerChildBehavior(this.typeaheadLink, (behavior: ITypeaheadBehavior): void => {
 				behavior.add(item);
 			});

--- a/source/components/typeaheadList/typeaheadList.ts
+++ b/source/components/typeaheadList/typeaheadList.ts
@@ -196,7 +196,6 @@ export class TypeaheadListController implements ITypeaheadListBindings {
 	}
 
 	private filter(list: any[], search: string): any[] {
-		search = search || '';
 		const filteredList: any[] = _.filter(list, (item: any): boolean => {
 			return !_.find(this.ngModel.$viewValue, item);
 		});


### PR DESCRIPTION
Set the typeahead ngModel to dirty when items are added/removed. Hide the header when the list is empty.

Also fixed issue with genericContainer where $onChanges was getting triggered before the container was set up. The initial template will always be set after initialization, so we don't need to watch for changes until after the setup.
