### PR TITLE
Need to provide a default 'empty' jquery element.

### DIFF
--- a/source/services/contentProvider/contentProvider.service.ts
+++ b/source/services/contentProvider/contentProvider.service.ts
@@ -23,7 +23,7 @@ export interface IContentProviderService {
 
 class ContentProviderService implements IContentProviderService {
 	constructor() {
-		this.contentChanges = new BehaviorSubject<IContentChanges>(<any>{});
+		this.contentChanges = new BehaviorSubject<IContentChanges>(<any>{ newContent: ng.element('') });
 	}
 
 	private content: JQuery;


### PR DESCRIPTION
Because we call `.filter` on it, which breaks if it's not specified.
