### PR TITLE
Typeahead list - hide dropdown if empty

### DIFF
--- a/source/components/typeaheadList/typeaheadList.html
+++ b/source/components/typeaheadList/typeaheadList.html
@@ -1,6 +1,6 @@
 <rl-generic-container selector="list.disableSearching">
 	<template when-selector="true">
-		<rl-select ng-model="list.model" select="list.addItem(item)" selector="list.transform"
+		<rl-select ng-if="list.cachedItems | isEmpty:false" ng-model="list.model" select="list.addItem(item)" selector="list.transform"
 				   options="list.cachedItems" label="{{list.label}}" ng-disabled="list.ngDisabled"></rl-select>
 	</template>
 	<template default>


### PR DESCRIPTION
When searching is disabled, hide the dropdown if there are no options left. In this case there is no action that is possible with the dropdown, so it makes more sense to hide it altogether.
