### PR TITLE
Fix custom search feature and clean up timing issues

### DIFF
--- a/source/components/typeahead/typeahead.ts
+++ b/source/components/typeahead/typeahead.ts
@@ -106,7 +106,7 @@ export class TypeaheadController extends InputController {
 	childLink: __parentChild.IChild<ITypeaheadBehavior>;
 	hasSelection: boolean;
 	select: { (params: ISelectParams): void };
-	create: { (params: ICreateParams): void };
+	create: { (params: ICreateParams): any };
 	transform: { (item: any): string } | string;
 	getItems: { (params?: IGetItemsParams): angular.IPromise<any> };
 	prefix: string;
@@ -122,7 +122,6 @@ export class TypeaheadController extends InputController {
 	collapseOnSelect: boolean;
 	allowCustomOption: boolean;
 	collapsed: boolean = false;
-	hasSearchOption: boolean = false;
 
 	get selection(): any {
 		return this.ngModel.$viewValue;
@@ -215,7 +214,6 @@ export class TypeaheadController extends InputController {
 			this._searchOption.text = search;
 
 			if (this.showCustomSearch(search)) {
-				this.hasSearchOption = true;
 				this.visibleItems.unshift(this._searchOption);
 			}
 		});
@@ -223,21 +221,34 @@ export class TypeaheadController extends InputController {
 
 	loadItems(search: string): angular.IPromise<void> {
 		if (!this.useClientSearching) {
-			return this.$q.when(this.getItems({
-				search: search,
-			})).then((items: any[]): void => {
-				this.visibleItems = items;
-			});
+			return this.getItems({ search: search })
+				.then((items: any[]): void => {
+					this.visibleItems = items;
+				});
 		} else {
-			if (this.cachedItems != null) {
-				this.visibleItems = this.filter(this.cachedItems, search);
-				return this.$q.when();
-			} else {
-				return this.$q.when(this.getItems()).then((items: any[]): void => {
-					this.cachedItems = items;
+			return this.getItemsClient()
+				.then((items: any[]): void => {
 					this.visibleItems = this.filter(items, search);
 				});
-			}
+		}
+	}
+
+	private getItemsPromise: angular.IPromise<any[]>;
+
+	private getItemsClient(): angular.IPromise<any[]> {
+		if (this.cachedItems != null) {
+			return this.$q.when(this.cachedItems);
+		}
+		//when useClientSearching is enabled, the entire list is loaded and then filtered in-memory
+		//caching the promise prevents multiple API calls from being made to load the entire list
+		else if (this.getItemsPromise != null) {
+			return this.getItemsPromise;
+		}
+		else {
+			return this.getItemsPromise = this.getItems()
+				.then((items: any[]): any[] => {
+					return this.cachedItems = items;
+				});
 		}
 	}
 
@@ -248,7 +259,6 @@ export class TypeaheadController extends InputController {
 
 	private showCustomSearch(search: string): boolean {
 		return this.allowCustomOption
-			&& !this.hasSearchOption
 			&& !_.find(this.visibleItems, (item: any): boolean => {
 			return this.getDisplayName(item) === search;
 		});

--- a/source/components/typeahead/typeahead.ts
+++ b/source/components/typeahead/typeahead.ts
@@ -115,6 +115,7 @@ export class TypeaheadController extends InputController {
 	allowCollapse: boolean;
 
 	private cachedItems: any[];
+	private getItemsPromise: angular.IPromise<any[]>;
 	visibleItems: any[];
 	loading: boolean = false;
 	loadDelay: number;
@@ -232,8 +233,6 @@ export class TypeaheadController extends InputController {
 				});
 		}
 	}
-
-	private getItemsPromise: angular.IPromise<any[]>;
 
 	private getItemsClient(): angular.IPromise<any[]> {
 		if (this.cachedItems != null) {


### PR DESCRIPTION
Removed the hasSearchOption variable.  The first custom option was being added correctly, but usage of the hasSearchOption flag was preventing subsequent custom options from being added.

Changed the return type of the create property from void to any.  This matches the interface definition.

Removed $q.when wrapper on call to this.getItems(), as the getItems function is defined to return a promise.  Wrapping a promise in $q.when is an anti-pattern.

Refactored branch of loadItems function that handles the useClientSearching case.  When useClientSearching is enabled, the API should be called one time to load the entire list, then the search text is filtered on the client.  However, it was possible for a user who types quickly to trigger the API call more than once.  Fixed this by caching the promise returned from the getItems function.
