### PR TITLE
Check validation result before searching

### DIFF
--- a/source/components/cardContainer/cardSearch/cardSearch.ts
+++ b/source/components/cardContainer/cardSearch/cardSearch.ts
@@ -5,7 +5,6 @@ import * as angular from 'angular';
 import { services } from 'typescript-angular-utilities';
 import __genericSearchFilter = services.genericSearchFilter;
 
-import { IDataSource } from '../dataSources/dataSource';
 import { CardContainerController } from '../cardContainer';
 
 export let moduleName: string = 'rl.ui.components.cardContainer.cardSearch';
@@ -49,7 +48,9 @@ export class CardSearchController {
 			this.$timeout.cancel(this.timer);
 		}
 
-		this.timer = this.$timeout<void>(this.cardContainer.dataSource.refresh.bind(this.cardContainer.dataSource), this.delay);
+		if (!this.searchLengthError) {
+			this.timer = this.$timeout<void>(this.cardContainer.dataSource.refresh.bind(this.cardContainer.dataSource), this.delay);
+		}
 	}
 
 	static $inject: string[] = ['$timeout'];


### PR DESCRIPTION
The data source was being refreshed and bound regardless of whether calling validateSearchLength resulted in a search length error or not.  This resulted in the UI showing a validation error but still performing the search.

Also removed unused import IDataSource.

Unit tests passed.

Resolves issue: https://renovo.myjetbrains.com/youtrack/issue/MUSIC-532
