### PR TITLE
Show/hide UI message w/o API call

### DIFF
--- a/source/components/messageLog/messageLog.service.ts
+++ b/source/components/messageLog/messageLog.service.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as ng from 'angular';
 import * as moment from 'moment';
 

--- a/source/components/messageLog/messageLog.service.ts
+++ b/source/components/messageLog/messageLog.service.ts
@@ -1,5 +1,10 @@
+'use strict';
+
 import * as ng from 'angular';
 import * as moment from 'moment';
+
+import { services } from 'typescript-angular-utilities';
+import __array = services.array;
 
 export var factoryName: string = 'messageLog';
 
@@ -63,6 +68,8 @@ export class MessageLog {
 	busy: boolean;
 	visibleMessages: IMessage[];
 
+	constructor(private arrayUtility: __array.IArrayUtility) { }
+
 	get pageSize(): number {
 		return this._pageSize;
 	}
@@ -98,8 +105,12 @@ export class MessageLog {
 	/* tslint:enable */
 
 	addMessage(message: IMessage): ng.IPromise<void> {
+		this.visibleMessages.unshift(message);
+
 		return this.dataService.saveMessage(message).then((): void => {
 			this.getTopPage();
+		}).catch((error): void => {
+			this.arrayUtility.remove(this.visibleMessages, message);
 		});
 	}
 
@@ -167,11 +178,13 @@ export interface IMessageLogFactory {
 	getInstance(): IMessageLog;
 }
 
-export function messageLogFactory(): IMessageLogFactory {
+messageLogFactory.$inject = [__array.serviceName];
+
+export function messageLogFactory(arrayUtility: __array.IArrayUtility): IMessageLogFactory {
 	'use strict';
 	return {
 		getInstance(): IMessageLog {
-			return new MessageLog();
+			return new MessageLog(arrayUtility);
 		},
 	};
 }


### PR DESCRIPTION
These changes help resolve an issue that was causing the message log to continue displaying an uploading graphic after a failed upload.

The call to dataService.saveMessage was resolving immediately due to a promise anti-pattern inside the Attachments Service.  This caused an API call to be made via getTopPage before the new message was actually saved.  It did, however, incidentally cause the message being added to show up on the screen because the Attachments Service was temporarily adding it to the list when getMessages was called (again via getTopPage).

In a separate commit, the Attachments Service was updated to correctly return the actual promise for the file upload.  Subsequently, getTopPage was no longer being executed right away, and it made more sense for the MessageLog Service to temporarily add the message to the visibleMessages itself without making that API call through the Attachments Service.  Then the MessageLog Service also needs to remove the new message on failure, thus the need to import the arrayUtility.
