### PR TITLE
Tests and card cleanup

### DIFF
--- a/bootstrapper/misc/miscNg2.html
+++ b/bootstrapper/misc/miscNg2.html
@@ -13,6 +13,12 @@
 </div>
 
 <div class="form-group">
+	<div><label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/stringWithWatermark/stringWithWatermark.md">String with watermark</a>:</label></div>
+	<rl-textbox ng-model="misc.text"></rl-textbox>
+	<rl-string-with-watermark-ng [string]="misc.text" watermark="(empty)"></rl-string-with-watermark-ng>
+</div>
+
+<div class="form-group">
 	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/filters/date/date.filter.md">Date filter</a>:</label>
 	<div>{{misc.date | rlDate}}</div>
 	<div>{{misc.date | rlDate:true}}</div>

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rxjs": "5.0.0-beta.6",
     "signature_pad": "~1.5.3",
     "systemjs": "^0.19.28",
-    "typescript-angular-utilities": "~3.1.6",
+    "typescript-angular-utilities": "~3.1.7",
     "ui-select": "~0.14.7",
     "zone.js": "^0.6.12"
   },

--- a/source/components/cardContainer/card/card.tests.ts
+++ b/source/components/cardContainer/card/card.tests.ts
@@ -11,7 +11,6 @@ import { CardComponent } from './card';
 interface ICardContainerMock {
 	openCard: Sinon.SinonSpy;
 	dataSource: any;
-	registerCard: Sinon.SinonSpy;
 	columnTemplates?: any;
 }
 
@@ -26,15 +25,9 @@ describe('CardComponent', () => {
 				refresh: sinon.spy(),
 				remove: sinon.spy(),
 			},
-			registerCard: sinon.spy(),
 		};
 
 		card = new CardComponent(new __boolean.BooleanUtility(), new __notification.NotificationService(<any>{}, <any>{}), new FormService(), <any>cardContainer);
-	});
-
-	it('should register with the card container', (): void => {
-		sinon.assert.calledOnce(cardContainer.registerCard);
-		sinon.assert.calledWith(cardContainer.registerCard, card);
 	});
 
 	it('should pass the item to the save handler', (): void => {

--- a/source/components/cardContainer/card/card.ts
+++ b/source/components/cardContainer/card/card.ts
@@ -54,7 +54,6 @@ export class CardComponent<T> extends FormComponent {
 		super(notification, formService);
 		this.boolean = boolean;
 		this.cardContainer = cardContainer;
-		this.cardContainer.registerCard(this);
 		this.refresh.subscribe(() => this.cardContainer.dataSource.refresh());
 	}
 

--- a/source/components/cardContainer/cardContainer.tests.ts
+++ b/source/components/cardContainer/cardContainer.tests.ts
@@ -106,12 +106,13 @@ describe('CardContainerComponent', () => {
 			card = <any>{
 				close: sinon.spy((): boolean => { return true; }),
 			};
+			cardContainer.cardChildren = <any>{
+				toArray: () => [card],
+			};
 		});
 
 		it('should signal cards to close before a card opens', (): void => {
 			cardContainer.ngOnInit();
-
-			cardContainer.registerCard(card);
 
 			let okayToOpen: boolean = false;
 

--- a/source/components/cardContainer/cardContainer.ts
+++ b/source/components/cardContainer/cardContainer.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Inject, ContentChild, ContentChildren, QueryList, OnInit } from '@angular/core';
+import { Component, Input, Inject, ContentChild, ContentChildren, ViewChildren, QueryList, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
 import { isUndefined, isObject, each, map, find, take, every } from 'lodash';
 
@@ -68,7 +68,6 @@ export class CardContainerComponent<T> implements OnInit {
 	permanentFooters: boolean;
 	saveWhenInvalid: boolean;
 	sortDirection: ISortDirections;
-	cards: CardComponent<T>[] = [];
 
 	numberSelected: number = 0;
 	numberSelectedChanges: Subject<number> = new Subject<number>();
@@ -85,6 +84,12 @@ export class CardContainerComponent<T> implements OnInit {
 	@ContentChild(CardFooterTemplate) cardFooter: CardFooterTemplate;
 	@ContentChildren(ColumnContentTemplate) columnTemplates: QueryList<ColumnContentTemplate>;
 	@ContentChildren(ColumnHeaderTemplate) columnHeaders: QueryList<ColumnHeaderTemplate>;
+
+	@ViewChildren(CardComponent) cardChildren: QueryList<CardComponent<T>>;
+
+	get cards(): CardComponent<T>[] {
+		return this.cardChildren.toArray();
+	}
 
 	constructor( @Inject(__object.objectToken) object: __object.IObjectUtility
 			, @Inject(__array.arrayToken) array: __array.IArrayUtility
@@ -113,10 +118,6 @@ export class CardContainerComponent<T> implements OnInit {
 		if (this.dataSource.sorts == null) {
 			this.dataSource.sorts = [];
 		}
-	}
-
-	registerCard(card: CardComponent<T>): void {
-		this.cards.push(card);
 	}
 
 	openCard(): boolean {

--- a/source/components/commaList/commaList.tests.ts
+++ b/source/components/commaList/commaList.tests.ts
@@ -1,0 +1,67 @@
+import { services } from 'typescript-angular-utilities';
+import __object = services.object;
+import __transform = services.transform;
+
+import { CommaListComponent } from './commaList';
+
+interface ITestObject {
+	prop: string;
+}
+
+describe('CommaListComponent', () => {
+	let commaList: CommaListComponent<any>;
+
+	beforeEach(() => {
+		commaList = new CommaListComponent<any>(__object.objectUtility, __transform.transform);
+	});
+
+	it('shoult limit to 3 items on the scope', (): void => {
+		commaList.list = ['item1', 'item2', 'item3', 'item4', 'item5'];
+		commaList.max = 3;
+
+		const list: string[] = commaList.getFirstItems();
+
+		expect(commaList.remainingItems).to.equal(2);
+		expect(list).to.have.length(3);
+		expect(list[0]).to.equal('item1');
+		expect(list[1]).to.equal('item2');
+		expect(list[2]).to.equal('item3');
+	});
+
+	it('should show all items if no max is provided', (): void => {
+		commaList.ngOnInit();
+		commaList.list = ['item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7', 'item8', 'item9', 'item10'];
+		expect(commaList.getFirstItems()).to.have.length(10);
+	});
+
+	it('should show none if 0 is specified as the max', (): void => {
+		commaList.list = ['item1', 'item2', 'item3', 'item4', 'item5'];
+		commaList.max = 0;
+
+		const list: string[] = commaList.getFirstItems();
+
+		expect(list).to.have.length(0);
+		expect(commaList.remainingItems).to.equal(5);
+	});
+
+	it('should transform the list items if a transform function is provided', (): void => {
+		let transform: { (item: ITestObject): string } = (item: ITestObject): string => {
+			return item.prop;
+		};
+		let baseList: ITestObject[] = [
+			{ prop: 'item1' },
+			{ prop: 'item2' },
+			{ prop: 'item3' },
+		];
+
+		commaList.list = baseList;
+		commaList.max = 3;
+		commaList.transform = transform;
+
+		const filteredList: string[] = commaList.getFirstItems();
+
+		expect(filteredList[0]).to.equal('item1');
+		expect(filteredList[1]).to.equal('item2');
+		expect(filteredList[2]).to.equal('item3');
+	});
+});

--- a/source/components/components.module.ts
+++ b/source/components/components.module.ts
@@ -26,7 +26,7 @@ import * as select from './inputs/select/select.ng1';
 import * as signaturePad from './signaturePad/signaturePad';
 import * as simpleCardList from './simpleCardList/simpleCardList.module';
 import * as spinner from './inputs/spinner/spinner.ng1';
-import * as stringWithWatermark from './stringWithWatermark/stringWithWatermark';
+import * as stringWithWatermark from './stringWithWatermark/stringWithWatermark.ng1';
 import * as tabs from './tabs/tabs.module';
 import * as templateRenderer from './templateRenderer/templateRenderer.ng1';
 import * as textarea from './inputs/textarea/textarea.ng1';

--- a/source/components/form/form.tests.ts
+++ b/source/components/form/form.tests.ts
@@ -1,0 +1,73 @@
+import { FormComponent } from './form';
+import { isFunction } from 'lodash';
+
+interface INotificationMock {
+	warning: Sinon.SinonSpy;
+}
+
+interface IFormServiceMock {
+	isFormValid?: Sinon.SinonSpy;
+	getAggregateError?: Sinon.SinonSpy;
+}
+
+describe('FormComponent', (): void => {
+	let form: FormComponent;
+	let notification: INotificationMock;
+	let formService: IFormServiceMock;
+
+	beforeEach((): void => {
+		notification = { warning: sinon.spy() };
+		formService = {};
+
+		form = new FormComponent(<any>notification, <any>formService);
+		form.form = <any>{};
+	});
+
+	it('should default save if not specified', (): void => {
+		expect(isFunction(form.save)).to.be.true;
+	});
+
+	it('should save using the current form value', (): void => {
+		const saveSpy = sinon.spy();
+		form.save = saveSpy;
+		const value = { prop: 'something' };
+		form.form.value = value;
+
+		form.saveForm();
+
+		sinon.assert.calledOnce(saveSpy);
+		sinon.assert.calledWith(saveSpy, value);
+	});
+
+	describe('submit', (): void => {
+		it('should save the form if valid', (): void => {
+			const saveSpy = sinon.spy();
+			form.saveForm = saveSpy;
+			const isValidSpy = sinon.spy(() => true);
+			formService.isFormValid = isValidSpy;
+			form.form = <any>{};
+
+			form.submit();
+
+			sinon.assert.calledOnce(isValidSpy);
+			sinon.assert.calledWith(isValidSpy, form.form);
+			sinon.assert.calledOnce(saveSpy);
+		});
+
+		it('should show a warning if invalid', (): void => {
+			const isValidSpy = sinon.spy(() => false);
+			formService.isFormValid = isValidSpy;
+			const getErrorSpy = sinon.spy(() => 'error');
+			formService.getAggregateError = getErrorSpy;
+			form.form = <any>{};
+
+			form.submit();
+
+			sinon.assert.calledOnce(isValidSpy);
+			sinon.assert.calledWith(isValidSpy, form.form);
+			sinon.assert.calledOnce(getErrorSpy);
+			sinon.assert.calledOnce(notification.warning);
+			sinon.assert.calledWith(notification.warning, 'error');
+		});
+	});
+});

--- a/source/components/simpleCardList/simpleCard.html
+++ b/source/components/simpleCardList/simpleCard.html
@@ -1,4 +1,4 @@
-<div class="card col-xs-12 {{cardType}}">
+<div class="card col-xs-12 {{cardType}} {{alternatingClass}}">
 	<div class="header row"
 		 [class.active]="canOpen && !alwaysOpen"
 		 (click)="toggle()">

--- a/source/components/simpleCardList/simpleCard.tests.ts
+++ b/source/components/simpleCardList/simpleCard.tests.ts
@@ -8,7 +8,6 @@ import { SimpleCardListComponent } from './simpleCardList';
 
 interface IListMock {
 	openCard: Sinon.SinonSpy;
-	registerCard: Sinon.SinonSpy;
 }
 
 interface IFormMock {
@@ -22,17 +21,9 @@ describe('SimpleCardComponent', () => {
 	beforeEach(() => {
 		list = {
 			openCard: sinon.spy(() => true),
-			registerCard: sinon.spy(),
 		};
 
 		card = new SimpleCardComponent(new __boolean.BooleanUtility, <any>{}, null, <any>list);
-	});
-
-	it('should register  with the list', (): void => {
-		card.ngOnInit();
-
-		sinon.assert.calledOnce(list.registerCard);
-		sinon.assert.calledWith(list.registerCard, card);
 	});
 
 	it('should create an empty list if no list is provided', (): void => {

--- a/source/components/simpleCardList/simpleCard.ts
+++ b/source/components/simpleCardList/simpleCard.ts
@@ -33,6 +33,7 @@ export class SimpleCardComponent<T> extends FormComponent implements OnInit {
 
 	showContent: boolean = false;
 	list: SimpleCardListComponent<T>;
+	alternatingClass: string = '';
 	private boolean: __boolean.IBooleanUtility;
 
 	constructor(@Inject(__boolean.booleanToken) boolean: __boolean.IBooleanUtility
@@ -46,7 +47,6 @@ export class SimpleCardComponent<T> extends FormComponent implements OnInit {
 
 	ngOnInit(): void {
 		this.canOpen = this.canOpen != null ? this.canOpen : true;
-		this.list.registerCard(this);
 	}
 
 	toggle(): void {
@@ -83,7 +83,7 @@ export class SimpleCardComponent<T> extends FormComponent implements OnInit {
 	}
 
 	private emptyList(): SimpleCardListComponent<T> {
-		const list: SimpleCardListComponent<T> = new SimpleCardListComponent<T>();
+		const list: SimpleCardListComponent<T> = new SimpleCardListComponent<T>(null);
 		list.openCard = () => true;
 		return list;
 	}

--- a/source/components/simpleCardList/simpleCardList.tests.ts
+++ b/source/components/simpleCardList/simpleCardList.tests.ts
@@ -1,27 +1,25 @@
+import { services } from 'typescript-angular-utilities';
+import __number = services.number;
+
 import { SimpleCardListComponent } from './simpleCardList';
 
 interface ICardMock {
 	close?: Sinon.SinonSpy;
 	alwaysOpen?: boolean;
+	alternatingClass?: string;
 }
 
 describe('SimpleCardListComponent', () => {
 	let list: SimpleCardListComponent<any>;
 	let alwaysOpen: boolean;
+	let cards: any[];
 
 	beforeEach(() => {
-		list = new SimpleCardListComponent();
-	});
-
-	it('should save a list of cards and set alwaysOpen on them', (): void => {
-		list.alwaysOpen = true;
-		const card: ICardMock = {};
-
-		list.registerCard(<any>card);
-
-		expect(list.cards).to.have.length(1);
-		expect(list.cards[0]).to.equal(card);
-		expect(card.alwaysOpen).to.be.true;
+		list = new SimpleCardListComponent(__number.numberUtility);
+		cards = [];
+		list.cardChildren = <any>{
+			toArray: () => cards,
+		};
 	});
 
 	it('should trigger all cards to close on openCard and return true if all are successful', (): void => {
@@ -31,8 +29,8 @@ describe('SimpleCardListComponent', () => {
 		const card2: ICardMock = {
 			close: sinon.spy(() => true),
 		};
-		list.registerCard(<any>card1);
-		list.registerCard(<any>card2);
+		cards.push(<any>card1);
+		cards.push(<any>card2);
 
 		const canOpen: boolean = list.openCard();
 
@@ -48,8 +46,8 @@ describe('SimpleCardListComponent', () => {
 		const cardCantClose: ICardMock = {
 			close: sinon.spy(() => false),
 		};
-		list.registerCard(<any>card1);
-		list.registerCard(<any>cardCantClose);
+		cards.push(<any>card1);
+		cards.push(<any>cardCantClose);
 
 		const canOpen: boolean = list.openCard();
 
@@ -61,12 +59,27 @@ describe('SimpleCardListComponent', () => {
 	it('should update alwaysOpen on each card on changes', (): void => {
 		list.alwaysOpen = true;
 		const card: ICardMock = {};
-		list.registerCard(<any>card);
+		cards.push(<any>card);
 
 		list.ngOnChanges({
 			alwaysOpen: <any>{ currentValue: true },
 		});
 
 		expect(card.alwaysOpen).to.be.true;
+	});
+
+	it('should set class card-odd on the even indexed cards', (): void => {
+		const card1: ICardMock = {};
+		const card2: ICardMock = {};
+		cards.push(<any>card1);
+		cards.push(<any>card2);
+		list.alwaysOpen = true;
+
+		list.ngAfterViewChecked();
+
+		expect(card1.alternatingClass).to.equal('card-odd');
+		expect(card1.alwaysOpen).to.be.true;
+		expect(card2.alternatingClass).to.be.empty;
+		expect(card2.alwaysOpen).to.be.true;
 	});
 });

--- a/source/components/simpleCardList/simpleCardList.ts
+++ b/source/components/simpleCardList/simpleCardList.ts
@@ -1,5 +1,8 @@
-import { Component, Input, SimpleChange, OnChanges } from '@angular/core';
+import { Component, Input, Inject, SimpleChange, OnChanges, AfterViewChecked, ContentChildren, QueryList } from '@angular/core';
 import { every, each } from 'lodash';
+
+import { services } from 'typescript-angular-utilities';
+import __number = services.number;
 
 import { SimpleCardComponent } from './simpleCard';
 
@@ -15,14 +18,21 @@ export interface IListChanges {
 				<ng-content></ng-content>
 			</span>`,
 })
-export class SimpleCardListComponent<T> implements OnChanges {
+export class SimpleCardListComponent<T> implements OnChanges, AfterViewChecked {
 	@Input() alwaysOpen: boolean;
 
-	cards: SimpleCardComponent<T>[] = [];
+	@ContentChildren(SimpleCardComponent) cardChildren: QueryList<SimpleCardComponent<T>>;
 
-	registerCard(card: SimpleCardComponent<T>): void {
-		card.alwaysOpen = this.alwaysOpen;
-		this.cards.push(card);
+	get cards(): SimpleCardComponent<T>[] {
+		return this.cardChildren != null
+			? this.cardChildren.toArray()
+			: [];
+	}
+
+	numberUtility: __number.INumberUtility;
+
+	constructor(@Inject(__number.numberToken) numberUtility: __number.INumberUtility) {
+		this.numberUtility = numberUtility;
 	}
 
 	openCard(): boolean {
@@ -33,5 +43,17 @@ export class SimpleCardListComponent<T> implements OnChanges {
 		if (changes.alwaysOpen) {
 			each(this.cards, card => { card.alwaysOpen = changes.alwaysOpen.currentValue; });
 		}
+	}
+
+	ngAfterViewChecked(): void {
+		each(this.cards, (card: SimpleCardComponent<T>, index: number): void => {
+			// mark the even indexed cards as 'odd', since they are the first, third, etc in the view
+			card.alternatingClass = this.numberUtility.isEven(index)
+								? 'card-odd'
+								: '';
+			if (this.alwaysOpen != null) {
+				card.alwaysOpen = this.alwaysOpen;
+			}
+		});
 	}
 }

--- a/source/components/stringWithWatermark/stringWithWatermark.html
+++ b/source/components/stringWithWatermark/stringWithWatermark.html
@@ -1,0 +1,4 @@
+<span [ngSwitch]="string | isEmpty">
+	<span *ngSwitchDefault>{{string}}</span>
+	<span class="watermark" *ngSwitchCase="true">{{watermark}}</span>
+</span>

--- a/source/components/stringWithWatermark/stringWithWatermark.ng1.ts
+++ b/source/components/stringWithWatermark/stringWithWatermark.ng1.ts
@@ -1,0 +1,26 @@
+import * as angular from 'angular';
+
+export const moduleName: string = 'rl.ui.components.stringWithWatermark';
+export const componentName: string = 'rlStringWithWatermark';
+
+export interface IStringWithWatermarkBindings {
+	string: string;
+	watermark: string;
+}
+
+const stringWithWatermark: angular.IComponentOptions = {
+	template: `
+		<rl-generic-container selector="controller.string | isEmpty">
+			<template when-selector="true"><span class="watermark">{{controller.watermark}}</span></template>
+			<template default><span>{{controller.string}}</span></template>
+		</rl-generic-container>
+	`,
+	controllerAs: 'controller',
+	bindings: {
+		string: '@',
+		watermark: '@',
+	},
+};
+
+angular.module(moduleName, [])
+	.component(componentName, stringWithWatermark);

--- a/source/components/stringWithWatermark/stringWithWatermark.ts
+++ b/source/components/stringWithWatermark/stringWithWatermark.ts
@@ -1,26 +1,13 @@
-import * as angular from 'angular';
+import { Component, Input } from '@angular/core';
 
-export const moduleName: string = 'rl.ui.components.stringWithWatermark';
-export const componentName: string = 'rlStringWithWatermark';
+import { filters } from 'typescript-angular-utilities';
 
-export interface IStringWithWatermarkBindings {
-	string: string;
-	watermark: string;
+@Component({
+	selector: 'rlStringWithWatermark',
+	template: require('./stringWithWatermark.html'),
+	pipes: [filters.isEmpty.IsEmptyPipe],
+})
+export class StringWithWatermarkComponent {
+	@Input() string: string;
+	@Input() watermark: string;
 }
-
-const stringWithWatermark: angular.IComponentOptions = {
-	template: `
-		<rl-generic-container selector="controller.string | isEmpty">
-			<template when-selector="true"><span class="watermark">{{controller.watermark}}</span></template>
-			<template default><span>{{controller.string}}</span></template>
-		</rl-generic-container>
-	`,
-	controllerAs: 'controller',
-	bindings: {
-		string: '@',
-		watermark: '@',
-	},
-};
-
-angular.module(moduleName, [])
-	.component(componentName, stringWithWatermark);

--- a/source/componentsDowngrade.ts
+++ b/source/componentsDowngrade.ts
@@ -17,6 +17,7 @@ import {
 import { CheckboxComponent, TextboxComponent } from './components/inputs/index';
 import { CommaListComponent } from './components/commaList/commaList';
 import { FormComponent } from './components/form/form';
+import { StringWithWatermarkComponent } from './components/stringWithWatermark/stringWithWatermark';
 
 import { CardContainerBuilder, DataSourceBuilder, FilterBuilder } from './components/cardContainer/builder/index';
 import { ColumnSearchFilter } from './components/cardContainer/filters/columnSearchFilter/columnSearchFilter.service';
@@ -86,6 +87,7 @@ export function downgradeComponentsToAngular1(upgradeAdapter: UpgradeAdapter) {
 	componentsDowngradeModule.directive('rlCommaListNg', <any>upgradeAdapter.downgradeNg2Component(CommaListComponent));
 	componentsDowngradeModule.directive('rlFormNg', <any>upgradeAdapter.downgradeNg2Component(FormComponent));
 	componentsDowngradeModule.directive('rlTextboxNg', <any>upgradeAdapter.downgradeNg2Component(TextboxComponent));
+	componentsDowngradeModule.directive('rlStringWithWatermarkNg', <any>upgradeAdapter.downgradeNg2Component(StringWithWatermarkComponent));
 
 	componentsDowngradeModule.factory(cardContainerBuilderServiceName, upgradeAdapter.downgradeNg2Provider(CardContainerBuilder));
 	componentsDowngradeModule.factory(dataPagerFactoryName, upgradeAdapter.downgradeNg2Provider(DataPager));

--- a/source/services/componentValidator/componentValidator.service.tests.ts
+++ b/source/services/componentValidator/componentValidator.service.tests.ts
@@ -1,0 +1,88 @@
+import { Subject } from 'rxjs';
+import { services } from 'typescript-angular-utilities';
+import __validation = services.validation;
+
+import { ComponentValidator } from './componentValidator.service';
+
+interface IControlMock {
+	statusChanges?: Subject<any>;
+	errors?: any;
+	rlErrorMessage?: string;
+	value?: any;
+}
+
+describe('ComponentValidator', () => {
+	let componentValidator: ComponentValidator;
+
+	beforeEach(() => {
+		componentValidator = new ComponentValidator(new __validation.ValidationService(<any>{}));
+	});
+
+	it('should register the validators', (): void => {
+		const registerSpy = sinon.spy();
+		componentValidator.validator.registerValidationHandler = registerSpy;
+		const validators: any[] = [{}, {}];
+
+		componentValidator.setValidators(validators);
+
+		sinon.assert.calledTwice(registerSpy);
+		sinon.assert.calledWith(registerSpy, validators[0]);
+		sinon.assert.calledWith(registerSpy, validators[1]);
+	});
+
+	it('should subscribe to status changes on the control', (): void => {
+		const setErrorSpy = sinon.spy();
+		componentValidator.setError = setErrorSpy;
+		const control: IControlMock = { statusChanges: new Subject() };
+
+		componentValidator.afterInit(<any>control);
+
+		sinon.assert.calledOnce(setErrorSpy);
+		sinon.assert.calledWith(setErrorSpy, control);
+		setErrorSpy.reset();
+
+		control.statusChanges.next(null);
+
+		sinon.assert.calledOnce(setErrorSpy);
+		sinon.assert.calledWith(setErrorSpy, control);
+	});
+
+	it('should return null if validation passes', (): void => {
+		const validateSpy = sinon.spy(() => true);
+		componentValidator.validator.validate = validateSpy;
+		const control: IControlMock = { value: 3 };
+
+		const result = componentValidator.validate(<any>control);
+
+		sinon.assert.calledOnce(validateSpy);
+		sinon.assert.calledWith(validateSpy, 3);
+		expect(result).to.be.null;
+	});
+
+	it('should return the error if validation fails', (): void => {
+		const validateSpy = sinon.spy(() => false);
+		componentValidator.validator.validate = validateSpy;
+		const control: IControlMock = { value: 3 };
+		componentValidator.error = 'error';
+		componentValidator.errorType = 'errorType';
+
+		const result = componentValidator.validate(<any>control);
+
+		sinon.assert.calledOnce(validateSpy);
+		sinon.assert.calledWith(validateSpy, 3);
+		expect(result['errorType']).to.equal('error');
+	});
+
+	it('should set rlErrorMessage on the control to the first error', (): void => {
+		const control: IControlMock = {
+			errors: {
+				myError: 'error',
+				otherError: 'other',
+			},
+		};
+
+		componentValidator.setError(<any>control);
+
+		expect(control.rlErrorMessage).to.equal('error');
+	});
+});

--- a/source/services/form/form.service.tests.ts
+++ b/source/services/form/form.service.tests.ts
@@ -1,0 +1,35 @@
+import { FormService } from './form.service';
+
+describe('FormService', (): void => {
+	let formService: FormService;
+
+	beforeEach(() => {
+		formService = new FormService();
+	});
+
+	it('should return true if every control is valid', (): void => {
+		const form: any = {
+			controls: [{ valid: true }, { valid: true }],
+		};
+		expect(formService.isFormValid(form)).to.be.true;
+	});
+
+	it('should return false if a control is invalid', (): void => {
+		const form: any = {
+			controls: [{ valid: true }, { valid: false }],
+		};
+		expect(formService.isFormValid(form)).to.be.false;
+	});
+
+	it('should get the first error message from a child of the form', (): void => {
+		const form: any = {
+			controls: [
+				{},
+				{},
+				{ rlErrorMessage: 'error1' },
+				{ rlErrorMessage: 'error2' },
+			],
+		};
+		expect(formService.getAggregateError(form)).to.equal('error1');
+	});
+});


### PR DESCRIPTION
Added unit tests for comma list, form, form service, and component validator. Implemented string with watermark in angular 2.

Converted both card list types to use @ children decorators instead of registering a list of cards. This lets us depend on angular to ensure that only the visible cards will appear in the list, and that they are in the correct order. Since the order is now dependable, we can apply a class to the 'odd' cards in a simple card list.

Requires https://github.com/RenovoSolutions/TypeScript-Angular-Utilities/pull/138
