### PR TITLE
Clone builders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-components",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "description": "Reusable responsive angular components",
   "author": "Renovo Development Team",
   "keywords": [

--- a/source/components/cardContainer/builder/cardContainerBuilder.service.ts
+++ b/source/components/cardContainer/builder/cardContainerBuilder.service.ts
@@ -1,4 +1,5 @@
 import { Injector, Injectable } from '@angular/core';
+import { clone } from 'lodash';
 
 import { filters, services } from 'typescript-angular-utilities';
 import __genericSearchFilter = services.genericSearchFilter;
@@ -74,9 +75,9 @@ export class CardContainerBuilder implements ICardContainerBuilder {
 			, dataSourceBuilder: DataSourceBuilder
 			, filterBuilder: FilterBuilder) {
 		this.injector = injector;
-		this.dataSource = dataSourceBuilder;
+		this.dataSource = clone(dataSourceBuilder);
 		this.dataSource.init(this);
-		this.filters = filterBuilder;
+		this.filters = clone(filterBuilder);
 		this.filters.init(this);
 		this._columns = [];
 	}


### PR DESCRIPTION
Clone the data source and filter builders. This fixes an issue with having multiple card containers in the same context.
