### PR TITLE
Updated rl-absolute-time's markup to handle the new styling.

### DIFF
--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -11,4 +11,5 @@
 	<div><rl-checkbox-ng disabled="true" label="Disabled"></rl-checkbox-ng></div>
 	<div><rl-checkbox-ng (change)="input.log($event)" label="Output event"></rl-checkbox-ng></div>
 	<div>Value: {{input.checked}}</div>
+	<div><rl-absolute-time></rl-absolute-time></div>
 </div>

--- a/source/components/inputs/absoluteTime/absoluteTime.html
+++ b/source/components/inputs/absoluteTime/absoluteTime.html
@@ -1,4 +1,4 @@
-<div class="field"
+<div class="field input-group"
 	[class.error]="!control.valid"
 	(offClick)="closeTimes()">
 	<label class="label-slide angular-animate" [hidden]="!(value && label)">{{label}}</label>
@@ -8,29 +8,40 @@
 		   (click)="toggleTimes()"
 		   [placeholder]="label"
 		   [disabled]="disabled" />
-	<span class="rl-time-period" (click)="togglePeriod()">{{period}}</span>
-	<span class="rl-times" *ngIf="showTimes">
-		<span class="rl-time-selected-hour"
-			  [hidden]="!hourSelected"
-			  (click)="deselectHour()">{{hour}}</span>
-		<ul class="rl-time-hours" [hidden]="hourSelected">
-			<li class="rl-time-hour"
-				*ngFor="let hour of allHours"
-				(click)="selectHour(hour)">
-				{{hour}}
-			</li>
-		</ul>
-		<span class="rl-time-selected-minute"
-			  [hidden]="!minuteSelected"
-			  (click)="deselectMinute()">{{minute | number:'2.0-0'}}</span>
-		<ul class="rl-time-minutes" [hidden]="minuteSelected">
-			<li class="rl-time-minute"
-				*ngFor="let minute of allMinutes"
-				(click)="selectMinute(minute)">
-				{{minute | number:'2.0-0'}}
-			</li>
-		</ul>
-	</span>
+	<div class="input-group-btn">
+		<button class="btn btn-default rl-time-period"
+				(click)="togglePeriod()">{{period}}</button>
+	</div>
+	<div class="rl-times" *ngIf="showTimes">
+		<div class="row">
+			<div class="col-xs-6 rl-time-group">
+				<div class="rl-time-title">Hour</div>
+				<div class="rl-time-selected-hour"
+					  [hidden]="!hourSelected"
+					  (click)="deselectHour()">{{hour}}</div>
+				<ul class="rl-time-hours" [hidden]="hourSelected">
+					<li class="rl-time-hour"
+						*ngFor="let hour of allHours"
+						(click)="selectHour(hour)">
+						{{hour}}
+					</li>
+				</ul>
+			</div>
+			<div class="col-xs-6 rl-time-group">
+				<div class="rl-time-title">Minute</div>
+				<div class="rl-time-selected-minute"
+					  [hidden]="!minuteSelected"
+					  (click)="deselectMinute()">{{minute | number:'2.0-0'}}</div>
+				<ul class="rl-time-minutes" [hidden]="minuteSelected">
+					<li class="rl-time-minute"
+						*ngFor="let minute of allMinutes"
+						(click)="selectMinute(minute)">
+						{{minute | number:'2.0-0'}}
+					</li>
+				</ul>
+			</div>
+		</div>
+	</div>
 	<div [hidden]="control.valid" class="error-string">
 		{{componentValidator.error}}
 	</div>


### PR DESCRIPTION
- Time period is now a button.
- Added groups & group titles.
- Broke down into columns using Bootstrap.
- Example on inputsNg2

![absolute-time](https://cloud.githubusercontent.com/assets/13574057/16427154/13ef4fbc-3d3a-11e6-9338-eba5d99fff66.gif)

Style PR: https://github.com/RenovoSolutions/RenovoTheme/pull/196
