### PR TITLE
Replace timeoutService with setTimeout and clearTimeout

### DIFF
--- a/source/services/autosave/triggers/onChangeTrigger.tests.ts
+++ b/source/services/autosave/triggers/onChangeTrigger.tests.ts
@@ -1,6 +1,5 @@
 import { services } from 'typescript-angular-utilities';
 import test = services.test;
-import __timeout = services.timeout;
 
 import { OnChangeTrigger, OnChangeSettings } from './onChangeTrigger';
 import { ITrigger } from './trigger';
@@ -27,7 +26,6 @@ describe('onChangeTrigger', () => {
 	let setPristineSpy: Sinon.SinonSpy;
 	let baseContentForm: IMockFormController;
 	let $rootScope: ng.IRootScopeService;
-	let timeoutService: __timeout.TimeoutService;
 	let emptyChangeListener: { (): IListener };
 
 	beforeEach(() => {
@@ -53,7 +51,7 @@ describe('onChangeTrigger', () => {
 
 		saveSpy = sinon.spy((): ng.IPromise<void> => { return $q.when(); });
 
-		trigger = new OnChangeTrigger($rootScope, new __timeout.TimeoutService());
+		trigger = new OnChangeTrigger($rootScope);
 	});
 
 	it('should trigger autosave when the form becomes dirty and valid after the debounce duration', test.fakeAsync((): void => {
@@ -130,7 +128,7 @@ describe('onChangeTrigger', () => {
 		sinon.assert.calledOnce(saveSpy);
 	}));
 
-	it.only('should reset the debounce timer on form changes', test.fakeAsync((): void => {
+	it('should reset the debounce timer on form changes', test.fakeAsync((): void => {
 		let triggerChange: { (): void };
 		let changeListener: any = (callback: { (): void }): Sinon.SinonSpy => {
 			triggerChange = callback;

--- a/source/services/autosave/triggers/onChangeTrigger.ts
+++ b/source/services/autosave/triggers/onChangeTrigger.ts
@@ -1,11 +1,8 @@
 import * as ng from 'angular';
 import * as _ from 'lodash';
 
-import { services, downgrade } from 'typescript-angular-utilities';
 import { ITrigger, Trigger } from './trigger';
 import { IListener, IClearListener } from './triggers.service';
-
-import __timeout = services.timeout;
 
 export interface OnChangeSettings {
 	form: ng.IFormController;
@@ -16,11 +13,11 @@ export interface OnChangeSettings {
 
 export class OnChangeTrigger extends Trigger<OnChangeSettings> implements ITrigger<OnChangeSettings> {
 	private debounceDuration: number;
-	private timer: __timeout.ITimeout;
+	private timer: number;
 	setListener: { (callback: IListener): IClearListener };
 	clearListener: IClearListener;
 
-	constructor(private $rootScope: ng.IRootScopeService, private timeoutService: __timeout.TimeoutService) {
+	constructor(private $rootScope: ng.IRootScopeService) {
 		super('onChange');
 	}
 
@@ -61,18 +58,15 @@ export class OnChangeTrigger extends Trigger<OnChangeSettings> implements ITrigg
 
 	private setTimer(autosave: { (): void }): void {
 		if (this.timer != null) {
-			this.timer.cancel();
-			this.timer = null;
+			clearTimeout(this.timer);
 		}
 
-		this.timer = this.timeoutService.setTimeout(this.debounceDuration)
-			.then((): void => {
-				this.clearListener();
-				autosave();
-				this.$rootScope.$digest();
-				this.timer = null;
-			})
-			.catch(() => null);
+		this.timer = setTimeout(() => {
+			this.clearListener();
+			autosave();
+			this.$rootScope.$digest();
+			this.timer = null;
+		}, this.debounceDuration);
 	}
 
 	private initListeners(): void {

--- a/source/services/autosave/triggers/triggers.service.ts
+++ b/source/services/autosave/triggers/triggers.service.ts
@@ -1,9 +1,6 @@
 import * as angular from 'angular';
 import * as _ from 'lodash';
 
-import { services, downgrade } from 'typescript-angular-utilities';
-import __timeout = services.timeout;
-
 import { OnChangeTrigger, OnChangeSettings } from './onChangeTrigger';
 import { ITrigger, Trigger } from './trigger';
 
@@ -36,9 +33,9 @@ export interface ITriggerService {
 class TriggerService implements ITriggerService {
 	triggers: ITriggers;
 
-	constructor($rootScope: angular.IRootScopeService, timeoutService: __timeout.TimeoutService) {
+	constructor($rootScope: angular.IRootScopeService) {
 		this.triggers = {
-			onChange: new OnChangeTrigger($rootScope, timeoutService),
+			onChange: new OnChangeTrigger($rootScope),
 			none: new Trigger<void>('none'),
 		};
 	}
@@ -60,11 +57,11 @@ export interface ITriggerServiceFactory {
 	getInstance(): ITriggerService;
 }
 
-triggerServiceFactory.$inject = ['$rootScope', downgrade.timeoutServiceName];
-function triggerServiceFactory($rootScope: angular.IRootScopeService, timeoutService: __timeout.TimeoutService): ITriggerServiceFactory {
+triggerServiceFactory.$inject = ['$rootScope'];
+function triggerServiceFactory($rootScope: angular.IRootScopeService): ITriggerServiceFactory {
 	return {
 		getInstance(): ITriggerService {
-			return new TriggerService($rootScope, timeoutService);
+			return new TriggerService($rootScope);
 		},
 	};
 }


### PR DESCRIPTION
By removing the proprietary `timeoutService` and taking advantage native implementations of `setTimeout` and `clearTimeout`, there is no longer a promise failure condition to catch and swallow.  Utitlizing native language features makes it easier for future devs to understand the code at a glance.

Also removed stray `only` function in tests.

Resolves issue: https://renovo.myjetbrains.com/youtrack/issue/MUSIC-386
