### PR TITLE
Simulate keyup event in datepicker

### DIFF
--- a/source/components/inputs/dateTime/dateTime.ng1.ts
+++ b/source/components/inputs/dateTime/dateTime.ng1.ts
@@ -126,6 +126,7 @@ export class DateTimeController extends InputController {
 		}).on('change.dp', (): void => {
 			let newValue: any = this.$element.find('input').val();
 			this.ngModel.$setViewValue(newValue);
+			this.$element.keyup();
 			this.$scope.$apply();
 		});
 	}


### PR DESCRIPTION
Clicking the minute up/down buttons in the datepicker control was flooding the message log.  The changes were not being debounced because the autosave directive only listens for keyup events.  Simulating a keyup event in the datepicker's change event handler triggers the debouncing features.

Resolves: https://renovo.myjetbrains.com/youtrack/issue/MUSIC-624
