### PR TITLE
When returning from the form submit, only return a boolean

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-components",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Reusable responsive angular components",
   "author": "Renovo Development Team",
   "keywords": [

--- a/source/components/form/form.ts
+++ b/source/components/form/form.ts
@@ -54,11 +54,11 @@ export class FormComponent {
 		}
 	}
 
-	submit(): IWaitValue<any> {
+	submit(): boolean {
 		if (this.validate()) {
 			const waitOn = this.saveForm();
 			this.resetAfterSubmit(waitOn);
-			return waitOn;
+			return true;
 		} else {
 			this.notification.warning(this.formService.getAggregateError(this.form));
 			return false;


### PR DESCRIPTION
All the consumer needs to know is whether the form successfully initiated the submission. The actual wait value is only relevant for showing the spinner and marking the form as pristine. This solves a dilemma where the wait value needs to be something other than false to avoid ambiguity between a false wait value and validation failures.
