### PR TITLE
Added a submitAndWait

### DIFF
--- a/source/components/buttons/buttonSubmit/buttonSubmit.tests.ts
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.tests.ts
@@ -1,7 +1,7 @@
 import { ButtonSubmitComponent } from './buttonSubmit';
 
 interface IMockForm {
-	submit: Sinon.SinonSpy;
+	submitAndWait: Sinon.SinonSpy;
 }
 
 interface IMockBusy {
@@ -19,7 +19,7 @@ describe('button submit', (): void => {
 
 	beforeEach((): void => {
 		form = {
-			submit: sinon.spy(() => 5),
+			submitAndWait: sinon.spy(() => 5),
 		};
 		buttonSubmit = new ButtonSubmitComponent(<any>form);
 
@@ -32,7 +32,7 @@ describe('button submit', (): void => {
 	it('should submit the form and pass the result to the spinner', (): void => {
 		buttonSubmit.submit();
 
-		sinon.assert.calledOnce(form.submit);
+		sinon.assert.calledOnce(form.submitAndWait);
 		sinon.assert.calledOnce(busy.trigger);
 		sinon.assert.calledWith(busy.trigger, 5);
 	});

--- a/source/components/buttons/buttonSubmit/buttonSubmit.ts
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.ts
@@ -23,7 +23,7 @@ export class ButtonSubmitComponent extends BaseButtonComponent {
 	}
 
 	submit(): void {
-		const waitValue: IWaitValue<any> = this.form.submit();
+		const waitValue: IWaitValue<any> = this.form.submitAndWait();
 		this.busySpinner.trigger(waitValue);
 	}
 }

--- a/source/components/form/form.tests.ts
+++ b/source/components/form/form.tests.ts
@@ -55,6 +55,35 @@ describe('FormComponent', (): void => {
 		sinon.assert.calledWith(pushSpy, form.form);
 	});
 
+	describe('saveForm', (): void => {
+		it('should mark the form as pristine after the submit completes', fakeAsync((): void => {
+			const saveMock = mock.promise();
+			const setPristineSpy = sinon.spy();
+			form.save = saveMock;
+			formService.isFormValid = <any>(() => true);
+			form.markAsPristine = setPristineSpy;
+
+			form.saveForm();
+
+			sinon.assert.notCalled(setPristineSpy);
+
+			saveMock.flush();
+
+			sinon.assert.calledOnce(setPristineSpy);
+		}));
+
+		it('should mark the form as pristine immediately if no async action is returned', (): void => {
+			form.save = <any>(() => null);
+			const setPristineSpy = sinon.spy();
+			formService.isFormValid = <any>(() => true);
+			form.markAsPristine = setPristineSpy;
+
+			form.saveForm();
+
+			sinon.assert.calledOnce(setPristineSpy);
+		});
+	});
+
 	describe('submit', (): void => {
 		it('should save the form if valid', (): void => {
 			const saveSpy = sinon.spy();
@@ -86,31 +115,24 @@ describe('FormComponent', (): void => {
 			sinon.assert.calledWith(notification.warning, 'error');
 		});
 
-		it('should mark the form as pristine after the submit completes', fakeAsync((): void => {
-			const saveMock = mock.promise();
-			const setPristineSpy = sinon.spy();
-			form.saveForm = saveMock;
-			formService.isFormValid = <any>(() => true);
-			form.markAsPristine = setPristineSpy;
+		it('should return true if validation passes', (): void => {
+			const saveSpy = sinon.spy();
+			form.saveForm = saveSpy;
+			form.validate = sinon.spy(() => true);
 
-			form.submit();
+			const submitting = form.submit();
 
-			sinon.assert.notCalled(setPristineSpy);
+			expect(submitting).to.be.true;
+		});
 
-			saveMock.flush();
+		it('should return the wait value for saving the form', (): void => {
+			const saveSpy = sinon.spy(() => 'waiting');
+			form.saveForm = saveSpy;
+			form.validate = sinon.spy(() => true);
 
-			sinon.assert.calledOnce(setPristineSpy);
-		}));
+			const waitOn = form.submitAndWait();
 
-		it('should mark the form as pristine immediately if no async action is returned', (): void => {
-			form.saveForm = <any>(() => null);
-			const setPristineSpy = sinon.spy();
-			formService.isFormValid = <any>(() => true);
-			form.markAsPristine = setPristineSpy;
-
-			form.submit();
-
-			sinon.assert.calledOnce(setPristineSpy);
+			expect(waitOn).to.equal('waiting');
 		});
 	});
 });

--- a/source/components/form/form.ts
+++ b/source/components/form/form.ts
@@ -56,11 +56,19 @@ export class FormComponent {
 
 	submit(): boolean {
 		if (this.validate()) {
-			const waitOn = this.saveForm();
-			this.resetAfterSubmit(waitOn);
+			this.saveForm();
 			return true;
 		} else {
-			this.notification.warning(this.formService.getAggregateError(this.form));
+			this.showErrors();
+			return false;
+		}
+	}
+
+	submitAndWait(): IWaitValue<any> {
+		if (this.validate()) {
+			return this.saveForm();
+		} else {
+			this.showErrors();
 			return false;
 		}
 	}
@@ -70,13 +78,19 @@ export class FormComponent {
 	}
 
 	saveForm(): IWaitValue<any> {
-		return this.save(this.form.value);
+		const waitOn = this.save(this.form.value);
+		this.resetAfterSubmit(waitOn);
+		return waitOn;
 	}
 
 	markAsPristine(): void {
 		// TODO: remove this once angular provides a way to mark as pristine or reset the form
 		(<any>this.form)._pristine = true;
 		(<any>this.form)._dirty = false;
+	}
+
+	private showErrors(): void {
+		this.notification.warning(this.formService.getAggregateError(this.form));
 	}
 
 	private resetAfterSubmit(waitOn: IWaitValue<any>): void {


### PR DESCRIPTION
My recent changes to submit inadvertantly broke the submit button. I'd forgotton that the submit button relies on the result of submit to show its spinner. However, it still seems to make sense that a consumer that's programmatically submitting the form should expect to get a true/false result indicating if the action was successful. To accomodate this, I'll add a submitAndWait function that does the same thing, but returns the wait value instead. We'll move as much as possible into shared functions to reduce duplicate code. The only thing that's really duplicated now is the if check against the validation result.
