### PR TITLE
Need to downgrade the default theme provider, not use the token.

### DIFF
--- a/source/componentsDowngrade.ts
+++ b/source/componentsDowngrade.ts
@@ -73,7 +73,7 @@ export function downgradeComponentsToAngular1(upgradeAdapter: UpgradeAdapter) {
 	upgradeAdapter.addProvider(MergeSort);
 	upgradeAdapter.addProvider(cardContainerBuilderFactoryProvider);
 
-	componentsDowngradeModule.value(defaultThemeValueName, defaultThemeToken);
+	componentsDowngradeModule.value(defaultThemeValueName, upgradeAdapter.downgradeNg2Provider(defaultThemeToken));
 
 	componentsDowngradeModule.filter('rlDate', downgrade.PipeDowngrader(new DatePipe(services.object.objectUtility)));
 


### PR DESCRIPTION
I suspect this is why RL2 couldn't override the token and have it work for angular 1.
