### PR TITLE
New Button Loader [Component]

### DIFF
--- a/source/components/buttons/buttonAsync/buttonAsync.html
+++ b/source/components/buttons/buttonAsync/buttonAsync.html
@@ -1,9 +1,11 @@
 <button type="button"
 		class="btn {{configuredTypes}} {{configuredSize}}"
-		[class.btn-busy]="busySpinner?.loading"
+		[class.btn-loading]="busySpinner?.loading"
 		(click)="triggerAction($event)"
 		[disabled]="busySpinner?.loading || disabled">
 	<rlBusy *ngIf="rightAligned" size="half"></rlBusy>
-	<ng-content></ng-content>
+	<span class="btn-content">
+		<ng-content></ng-content>
+	</span>
 	<rlBusy *ngIf="!rightAligned" size="half"></rlBusy>
 </button>

--- a/source/components/buttons/buttonAsync/buttonAsync.html
+++ b/source/components/buttons/buttonAsync/buttonAsync.html
@@ -3,9 +3,8 @@
 		[class.btn-loading]="busySpinner?.loading"
 		(click)="triggerAction($event)"
 		[disabled]="busySpinner?.loading || disabled">
-	<rlBusy *ngIf="rightAligned" size="half"></rlBusy>
 	<span class="btn-content">
 		<ng-content></ng-content>
 	</span>
-	<rlBusy *ngIf="!rightAligned" size="half"></rlBusy>
+	<rlBusy></rlBusy>
 </button>

--- a/source/components/buttons/buttonAsync/buttonAsync.ng1.html
+++ b/source/components/buttons/buttonAsync/buttonAsync.ng1.html
@@ -1,5 +1,7 @@
-﻿<button type="button" class="btn {{::button.types}} {{::button.configuredSize}}" ng-class="{ 'btn-busy': button.busy }" ng-click="button.trigger()" ng-disabled="button.busy || button.ngDisabled">
+﻿<button type="button" class="btn {{::button.types}} {{::button.configuredSize}}" ng-class="{ 'btn-loading': button.busy }" ng-click="button.trigger()" ng-disabled="button.busy || button.ngDisabled">
 	<rl-busy ng-if="::button.rightAligned" loading="button.busy" size="half"></rl-busy>
-	<span ng-transclude></span>
+	<span class="btn-content">
+		<span ng-transclude></span>
+	</span>
 	<rl-busy ng-if="::!button.rightAligned" loading="button.busy" size="half"></rl-busy>
 </button>

--- a/source/components/buttons/buttonAsync/buttonAsync.ng1.html
+++ b/source/components/buttons/buttonAsync/buttonAsync.ng1.html
@@ -1,7 +1,6 @@
 ﻿<button type="button" class="btn {{::button.types}} {{::button.configuredSize}}" ng-class="{ 'btn-loading': button.busy }" ng-click="button.trigger()" ng-disabled="button.busy || button.ngDisabled">
-	<rl-busy ng-if="::button.rightAligned" loading="button.busy" size="half"></rl-busy>
 	<span class="btn-content">
 		<span ng-transclude></span>
 	</span>
-	<rl-busy ng-if="::!button.rightAligned" loading="button.busy" size="half"></rl-busy>
+	<rl-busy loading="button.busy"></rl-busy>
 </button>

--- a/source/components/buttons/buttonAsync/buttonAsync.ng1.ts
+++ b/source/components/buttons/buttonAsync/buttonAsync.ng1.ts
@@ -16,14 +16,12 @@ export interface IButtonBindings {
 	size: string;
 	type: string;
 	ngDisabled: boolean;
-	rightAligned: boolean;
 }
 
 export class ButtonAsyncController extends ButtonController {
 	// bindings
 	busy: boolean;
 	action: { (...params: any[]): angular.IPromise<any> | void };
-	rightAligned: boolean;
 
 	static $inject: string[] = [promiseServiceName];
 	constructor(private promiseUtility: IPromiseUtility) {
@@ -50,7 +48,6 @@ const buttonAsync: angular.IComponentOptions = buildButton({
 	template: require('./buttonAsync.ng1.html'),
 	bindings: {
 		busy: '<?',
-		rightAligned: '<?',
 	},
 	controller: controllerName,
 });

--- a/source/components/buttons/buttonAsync/buttonAsync.ts
+++ b/source/components/buttons/buttonAsync/buttonAsync.ts
@@ -4,7 +4,7 @@ import { Observable, Subject } from 'rxjs';
 import { BusyComponent, IWaitValue } from '../../busy/busy';
 import { BaseButtonComponent, baseInputs } from '../baseButton';
 
-export const asyncInputs = baseInputs.concat(['action', 'rightAligned']);
+export const asyncInputs = baseInputs.concat(['action']);
 
 export interface IAsyncAction {
 	($event: any): IWaitValue<any>;
@@ -18,7 +18,6 @@ export interface IAsyncAction {
 })
 export class ButtonAsyncComponent extends BaseButtonComponent {
 	action: IAsyncAction;
-	rightAligned: boolean;
 
 	@ViewChild(BusyComponent) busySpinner: BusyComponent;
 

--- a/source/components/buttons/buttonLongClick/buttonLongClick.html
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.html
@@ -4,10 +4,9 @@
 		(mouseleave)="stopAction()"
 		(mouseup)="stopAction()"
 		[disabled]="busySpinner?.loading || disabled">
-	<rlBusy *ngIf="rightAligned" size="half"></rlBusy>
 	<span class="long-click-text btn-content">
 		<ng-content></ng-content>
 	</span>
-	<rlBusy *ngIf="!rightAligned" size="half"></rlBusy>
+	<rlBusy></rlBusy>
 	<div class="long-click-progress"></div>
 </button>

--- a/source/components/buttons/buttonLongClick/buttonLongClick.html
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.html
@@ -1,11 +1,11 @@
 <button class="btn btn-long-click {{configuredTypes}} {{configuredSize}}"
-		[class.btn-busy]="busySpinner?.loading"
+		[class.btn-loading]="busySpinner?.loading"
 		(mousedown)="startAction()"
 		(mouseleave)="stopAction()"
 		(mouseup)="stopAction()"
 		[disabled]="busySpinner?.loading || disabled">
 	<rlBusy *ngIf="rightAligned" size="half"></rlBusy>
-	<span class="long-click-text">
+	<span class="long-click-text btn-content">
 		<ng-content></ng-content>
 	</span>
 	<rlBusy *ngIf="!rightAligned" size="half"></rlBusy>

--- a/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
@@ -2,10 +2,9 @@
 		ng-class="{ 'btn-loading': button.busy }"
 		ng-mousedown="button.startAction()" ng-mouseleave="button.stopAction()" ng-mouseup="button.stopAction()"
 		ng-disabled="button.busy || button.ngDisabled">
-	<rl-busy loading="button.busy" ng-if="button.rightAligned" size="half"></rl-busy>
 	<span ng-transclude class="long-click-text btn-content">
 		<i ng-show="button.icon != null" class="fa fa-{{button.icon}}"></i> {{button.text}}
 	</span>
-	<rl-busy loading="button.busy" ng-if="!button.rightAligned" size="half"></rl-busy>
+	<rl-busy loading="button.busy"></rl-busy>
 	<div class="long-click-progress"></div>
 </button>

--- a/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
@@ -1,9 +1,9 @@
 <button class="btn btn-long-click {{button.types}} {{button.configuredSize}}"
-		ng-class="{ 'btn-busy': button.busy }"
+		ng-class="{ 'btn-loading': button.busy }"
 		ng-mousedown="button.startAction()" ng-mouseleave="button.stopAction()" ng-mouseup="button.stopAction()"
 		ng-disabled="button.busy || button.ngDisabled">
 	<rl-busy loading="button.busy" ng-if="button.rightAligned" size="half"></rl-busy>
-	<span ng-transclude class="long-click-text">
+	<span ng-transclude class="long-click-text btn-content">
 		<i ng-show="button.icon != null" class="fa fa-{{button.icon}}"></i> {{button.text}}
 	</span>
 	<rl-busy loading="button.busy" ng-if="!button.rightAligned" size="half"></rl-busy>

--- a/source/components/buttons/buttonLongClick/buttonLongClick.ng1.ts
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.ng1.ts
@@ -77,7 +77,6 @@ let longClickButton: angular.IComponentOptions = buildButton({
 	bindings: {
 		warning: '@',
 		busy: '<?',
-		rightAligned: '<?',
 		// deprecated
 		onShortClickText: '@',
 		icon: '@',

--- a/source/components/buttons/buttonSubmit/buttonSubmit.html
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.html
@@ -3,9 +3,8 @@
 		[class.btn-loading]="saving"
 		(click)="submit()"
 		[disabled]="saving || disabled">
-	<rlBusy *ngIf="rightAligned" size="half"></rlBusy>
 	<span class="btn-content">
 		<ng-content></ng-content>
 	</span>
-	<rlBusy *ngIf="!rightAligned" size="half"></rlBusy>
+	<rlBusy></rlBusy>
 </button>

--- a/source/components/buttons/buttonSubmit/buttonSubmit.html
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.html
@@ -1,9 +1,11 @@
 <button type="submit"
 		class="btn {{configuredTypes}} {{configuredSize}}"
-		[class.btn-busy]="saving"
+		[class.btn-loading]="saving"
 		(click)="submit()"
 		[disabled]="saving || disabled">
 	<rlBusy *ngIf="rightAligned" size="half"></rlBusy>
-	<ng-content></ng-content>
+	<span class="btn-content">
+		<ng-content></ng-content>
+	</span>
 	<rlBusy *ngIf="!rightAligned" size="half"></rlBusy>
 </button>

--- a/source/components/buttons/buttonSubmit/buttonSubmit.ng1.html
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.ng1.html
@@ -1,5 +1,7 @@
 <button type="submit" class="btn {{::button.types}} {{::button.configuredSize}}" ng-class="{ 'btn-busy': button.saving }" ng-disabled="button.saving || button.ngDisabled">
 	<rl-busy ng-if="::button.rightAligned" loading="button.saving" size="half"></rl-busy>
-	<span ng-transclude></span>
+	<span class="btn-content">
+		<span ng-transclude></span>
+	</span>
 	<rl-busy ng-if="::!button.rightAligned" loading="button.saving" size="half"></rl-busy>
 </button>

--- a/source/components/buttons/buttonSubmit/buttonSubmit.ng1.html
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.ng1.html
@@ -1,7 +1,6 @@
 <button type="submit" class="btn {{::button.types}} {{::button.configuredSize}}" ng-class="{ 'btn-busy': button.saving }" ng-disabled="button.saving || button.ngDisabled">
-	<rl-busy ng-if="::button.rightAligned" loading="button.saving" size="half"></rl-busy>
 	<span class="btn-content">
 		<span ng-transclude></span>
 	</span>
-	<rl-busy ng-if="::!button.rightAligned" loading="button.saving" size="half"></rl-busy>
+	<rl-busy loading="button.saving"></rl-busy>
 </button>

--- a/source/components/buttons/buttonSubmit/buttonSubmit.ng1.ts
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.ng1.ts
@@ -10,7 +10,6 @@ export const componentName: string = 'rlButtonSubmit';
 const buttonSubmit: angular.IComponentOptions = buildButton({
 		template: require('./buttonSubmit.ng1.html'),
 		bindings: {
-			rightAligned: '<?',
 			saving: '<?',
 			action: null,
 		},

--- a/source/components/buttons/buttonSubmit/buttonSubmit.ts
+++ b/source/components/buttons/buttonSubmit/buttonSubmit.ts
@@ -11,7 +11,6 @@ import { FormComponent } from '../../form/form';
 	directives: [BusyComponent],
 })
 export class ButtonSubmitComponent extends BaseButtonComponent {
-	@Input() rightAligned: boolean;
 
 	@ViewChild(BusyComponent) busySpinner: BusyComponent;
 


### PR DESCRIPTION
![test-loader](https://cloud.githubusercontent.com/assets/13574057/16699406/ec52ab94-4521-11e6-8b73-72a92c4933ab.gif)

Removed the older gif loader, for a new css loader.
##### New Version
- Updated class from `btn-busy` to `.btn-loading`.
- Add `.btn-content` to wrap content/transclude so it can fade when loading.
- Removed rightAlign options. The new loader doesn't need to worry about alignment.
##### Theme Change https://github.com/RenovoSolutions/RenovoTheme/pull/203
