### PR TITLE
Multiple off clicks

### DIFF
--- a/bootstrapper/forms/formsNg2.html
+++ b/bootstrapper/forms/formsNg2.html
@@ -61,3 +61,8 @@
 	<rlUserRating name="userRating1" disabled="true"></rlUserRating>
 	<rlButtonSubmit rightAligned="true">Submit right</rlButtonSubmit>
 </rlForm>
+<h5>Broken validation</h5>
+<rlForm>
+	<rlTextbox [validator]="brokenValidator"></rlTextbox>
+	<rlButtonSubmit>Throw validation error</rlButtonSubmit>
+</rlForm>

--- a/bootstrapper/forms/formsNg2Bootstrapper.ts
+++ b/bootstrapper/forms/formsNg2Bootstrapper.ts
@@ -32,6 +32,7 @@ export class FormsBootstrapper {
 	rating: number;
 	time: string;
 	validator: any;
+	brokenValidator: any;
 
 	options: ITestItem[];
 	optionsAsync: Observable<ITestItem[]>;
@@ -54,6 +55,10 @@ export class FormsBootstrapper {
 		this.validator = {
 			validate: () => this.rating >= 3,
 			errorMessage: 'You must give at least 3 stars',
+		};
+		this.brokenValidator = {
+			validate: () => false,
+			errorMessage: null,
 		};
 	}
 

--- a/source/behaviors/offClick/offClick.ts
+++ b/source/behaviors/offClick/offClick.ts
@@ -1,4 +1,11 @@
-import { Directive, Host, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { Directive, Host, Output, EventEmitter, OnInit, OnDestroy, Inject } from '@angular/core';
+
+import { services } from 'typescript-angular-utilities';
+import __guid = services.guid;
+
+export interface IOffClickEvent extends MouseEvent {
+	rlEventIdentifier: string;
+}
 
 @Directive({
 	selector: '[offClick]',
@@ -9,7 +16,17 @@ import { Directive, Host, Output, EventEmitter, OnInit, OnDestroy } from '@angul
 export class OffClickDirective implements OnInit, OnDestroy {
 	@Output('offClick') offClick: EventEmitter<any> = new EventEmitter();
 
-	listener: { ($event: MouseEvent): void } = ($event) => this.offClick.emit($event);
+	listener: { ($event: MouseEvent): void } = ($event: IOffClickEvent) => {
+		if ($event.rlEventIdentifier !== this.identifier) {
+			this.offClick.emit($event);
+		}
+	};
+
+	identifier: string;
+
+	constructor(@Inject(__guid.guidToken) guidService: __guid.IGuidService) {
+		this.identifier = guidService.random();
+	}
 
 	ngOnInit() {
 		setTimeout(() => {
@@ -21,7 +38,7 @@ export class OffClickDirective implements OnInit, OnDestroy {
 		document.removeEventListener('click', this.listener);
 	}
 
-	onClick($event) {
-		$event.stopPropagation();
+	onClick($event: IOffClickEvent) {
+		$event.rlEventIdentifier = this.identifier;
 	}
 }

--- a/source/components/form/form.ts
+++ b/source/components/form/form.ts
@@ -90,7 +90,12 @@ export class FormComponent {
 	}
 
 	private showErrors(): void {
-		this.notification.warning(this.formService.getAggregateError(this.form));
+		const error = this.formService.getAggregateError(this.form);
+		if (error) {
+			this.notification.warning(error);
+		} else {
+			throw new Error('The form is invalid but there are no validation errors to show');
+		}
 	}
 
 	private resetAfterSubmit(waitOn: IWaitValue<any>): void {

--- a/source/services/autosave/autosave.service.tests.ts
+++ b/source/services/autosave/autosave.service.tests.ts
@@ -106,6 +106,9 @@ describe('autosave', () => {
 			contentForm: <any>baseContentForm,
 			triggers: 'none',
 		});
+		(<any>autosave).formService = {
+			getAggregateError: () => 'error',
+		};
 
 		let close: boolean = autosave.autosave();
 

--- a/source/services/autosave/autosave.service.ts
+++ b/source/services/autosave/autosave.service.ts
@@ -81,7 +81,12 @@ class AutosaveService implements IAutosaveService {
 
 			return true;
 		} else {
-			this.notification.warning(this.formService.getAggregateError(this.contentForm));
+			const error = this.formService.getAggregateError(this.contentForm);
+			if (error) {
+				this.notification.warning(error);
+			} else {
+				throw new Error('The form is invalid but there are no validation errors to show');
+			}
 			return false;
 		}
 	}

--- a/source/services/services.module.ts
+++ b/source/services/services.module.ts
@@ -40,11 +40,9 @@ angular.module(moduleName, [
 	componentValidator.moduleName,
 	contentProvider.moduleName,
 	dialog.moduleName,
-	documentWrapper.moduleName,
 	form.moduleName,
 	jquery.moduleName,
 	parentChild.moduleName,
 	promise.moduleName,
 	templateLoader.moduleName,
-	windowWrapper.moduleName,
 ]);


### PR DESCRIPTION
Tie a specific identifier to an offClick event instead of stopping propagation

When a document event is received, we can check to see if this is an event for the same off click or not. If so, we ignore it. This prevents any unexpected side effects from stopping propagation. For example, when multiple offClick directives were on a page, clicking on one would fail to trigger another, because event propagation was stopped.

Build on https://github.com/RenovoSolutions/TypeScript-Angular-Components/pull/286
Only the last commit is specific to this PR.
