### PR TITLE
Angular 2 Typeahead

### DIFF
--- a/bootstrapper/forms/formsNg2.html
+++ b/bootstrapper/forms/formsNg2.html
@@ -17,6 +17,11 @@
 		<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
 			<template let-option>#{{option.value}}</template>
 		</rlSelect>
+		<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
+		<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
+			<template let-option>Value - {{option.value}}</template>
+		</rlTypeahead>
+		<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
 		<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
 		<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
 		<rlValidationGroup [model]="rating" [validator]="validator">
@@ -39,6 +44,7 @@
 	<rlTextarea name="textarea1" label="Textarea 1" rlRequired="Required text area"></rlTextarea>
 	<rlSpinner name="spinner1" label="Spinner 1"></rlSpinner>
 	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
+	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
 	<rlDateTime name="dateTime1" label="DateTime"></rlDateTime>
 	<rlAbsoluteTime name="time1" label="AbsoluteTime"></rlAbsoluteTime>
 	<rlUserRating name="userRating1"></rlUserRating>
@@ -56,6 +62,7 @@
 	<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
 	<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
 	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
+	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
 	<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
 	<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
 	<rlUserRating name="userRating1" disabled="true"></rlUserRating>

--- a/bootstrapper/forms/formsNg2Bootstrapper.ts
+++ b/bootstrapper/forms/formsNg2Bootstrapper.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, ViewChild } from '@angular/core';
 import * as moment from 'moment';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { filter } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __timezone = services.timezone;
@@ -12,6 +13,10 @@ import { ValidationGroupComponent } from '../../source/components/validationGrou
 
 export interface ITestItem {
 	value: number;
+}
+
+export interface ITestItem2 {
+	value: string;
 }
 
 @Component({
@@ -36,10 +41,11 @@ export class FormsBootstrapper {
 
 	options: ITestItem[];
 	optionsAsync: Observable<ITestItem[]>;
+	typeaheadOptions: ITestItem2[];
 
 	@ViewChild('testForm') testForm: FormComponent;
 
-	constructor(@Inject(__timezone.timezoneToken) timezoneService: __timezone.ITimezoneService) {
+	constructor( @Inject(__timezone.timezoneToken) timezoneService: __timezone.ITimezoneService) {
 		timezoneService.setCurrentTimezone('-05:00');
 
 		this.text = 'Something is already entered';
@@ -60,6 +66,14 @@ export class FormsBootstrapper {
 			validate: () => false,
 			errorMessage: null,
 		};
+
+		this.typeaheadOptions = [
+			{ value: 'Option 1' },
+			{ value: 'Option 2' },
+			{ value: 'Option 3' },
+			{ value: 'Option 4' },
+			{ value: 'Option 5' },
+		];
 	}
 
 	wait(data: any): Observable<any> {
@@ -82,5 +96,21 @@ export class FormsBootstrapper {
 			return this.waitCallback(data);
 		}
 		return false;
+	}
+
+	getOptions = (): Observable<any> => {
+		return this.wait(this.typeaheadOptions);
+	}
+
+	searchOptions = (search: string): Observable<any> => {
+		return this.wait(filter(this.typeaheadOptions, option => option.value.search(search) != -1));
+	}
+
+	createOption = (text: string): any => {
+		return { value: text };
+	}
+
+	log(value: any): void {
+		console.log(value);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "rxjs": "5.0.0-beta.6",
     "signature_pad": "~1.5.3",
     "systemjs": "^0.19.28",
-    "typescript-angular-utilities": "~3.2.1",
+    "typescript-angular-utilities": "~3.2.2",
     "ui-select": "~0.14.7",
     "zone.js": "^0.6.12"
   },

--- a/source/components/inputs/index.ts
+++ b/source/components/inputs/index.ts
@@ -1,3 +1,4 @@
+import { AbsoluteTimeComponent } from './absoluteTime/absoluteTime';
 import { CheckboxComponent } from './checkbox/checkbox';
 import { DateTimeComponent } from './dateTime/dateTime';
 import { RADIO_DIRECTIVES } from './radio/index';
@@ -5,10 +6,11 @@ import { SelectComponent } from './select/select';
 import { SpinnerComponent } from './spinner/spinner';
 import { TextareaComponent } from './textarea/textarea';
 import { TextboxComponent } from './textbox/textbox';
-import { AbsoluteTimeComponent } from './absoluteTime/absoluteTime';
+import { TypeaheadComponent } from './typeahead/typeahead';
 import { UserRatingComponent } from './userRating/userRating';
 
 export const INPUT_DIRECTIVES: any[] = [
+	AbsoluteTimeComponent,
 	CheckboxComponent,
 	DateTimeComponent,
 	RADIO_DIRECTIVES,
@@ -16,10 +18,11 @@ export const INPUT_DIRECTIVES: any[] = [
 	SpinnerComponent,
 	TextareaComponent,
 	TextboxComponent,
-	AbsoluteTimeComponent,
+	TypeaheadComponent,
 	UserRatingComponent,
 ];
 
+export * from './absoluteTime/absoluteTime';
 export * from './checkbox/checkbox';
 export * from './dateTime/dateTime';
 export * from './radio/index';
@@ -27,4 +30,5 @@ export * from './select/select';
 export * from './spinner/spinner';
 export * from './textarea/textarea';
 export * from './textbox/textbox';
+export * from './typeahead/typeahead';
 export * from './userRating/userRating';

--- a/source/components/inputs/select/select.html
+++ b/source/components/inputs/select/select.html
@@ -1,25 +1,21 @@
 <div class="field"
 	 [class.error]="!control.valid"
-	 (offClick)="close()">
+	 (offClick)="list.close()">
 	<label class="label-slide angular-animate" [hidden]="!(value && label)">{{label}}</label>
 	<div class="form-control rl-select-trigger"
-		 (click)="toggle()"
+		 (click)="list.toggle()"
 		 [class.disabled]="disabled"
-		 [class.rl-select-open]="showOptions">
+		 [class.rl-select-open]="list.showOptions">
 		<span class="placeholder" [hidden]="value">{{label}}</span>
 		<span class="rl-select-choice">{{getDisplayName(value)}}</span>
 	</div>
-	<ul class="rl-select-list" *ngIf="showOptions">
+	<rlPopoutList #list
+				  [options]="wrappedOptions"
+				  [template]="template"
+				  [transform]="transform"
+				  (select)="select($event)">
 		<li class="rl-select-option rl-select-option-null" *ngIf="nullOption" (click)="select(null)">{{nullOption}}</li>
-		<li class="rl-select-option"
-			*ngFor="let option of wrappedOptions | async"
-			(click)="select(option)">
-			<span *ngIf="template">
-				<template [ngTemplateOutlet]="newTemplate()" [ngOutletContext]="{ $implicit: option }"></template>
-			</span>
-			<span *ngIf="!template">{{getDisplayName(option)}}</span>
-		</li>
-	</ul>
+	</rlPopoutList>
 	<rlBusy></rlBusy>
 	<div [hidden]="control.valid" class="error-string">
 		{{componentValidator.error}}

--- a/source/components/inputs/select/select.tests.ts
+++ b/source/components/inputs/select/select.tests.ts
@@ -77,7 +77,7 @@ describe('SelectComponent', () => {
 
 	it('should set the value and close the options', (): void => {
 		const closeSpy = sinon.spy();
-		dropdown.list = {
+		dropdown.list = <any>{
 			close: closeSpy,
 		};
 

--- a/source/components/inputs/select/select.tests.ts
+++ b/source/components/inputs/select/select.tests.ts
@@ -75,40 +75,17 @@ describe('SelectComponent', () => {
 		});
 	});
 
-	describe('dropdown', (): void => {
-		it('should toggle the options', (): void => {
-			expect(dropdown.showOptions).to.be.undefined;
+	it('should set the value and close the options', (): void => {
+		const closeSpy = sinon.spy();
+		dropdown.list = {
+			close: closeSpy,
+		};
 
-			dropdown.toggle();
+		dropdown.select(options[1]);
 
-			expect(dropdown.showOptions).to.be.true;
-
-			dropdown.toggle();
-
-			expect(dropdown.showOptions).to.be.false;
-		});
-
-		it('should close the options', (): void => {
-			dropdown.showOptions = true;
-			dropdown.close();
-			expect(dropdown.showOptions).to.be.false;
-		});
-
-		it('should do nothing if the options are already closed', (): void => {
-			dropdown.showOptions = false;
-			dropdown.close();
-			expect(dropdown.showOptions).to.be.false;
-		});
-
-		it('should set the value and close the options', (): void => {
-			dropdown.showOptions = true;
-
-			dropdown.select(options[1]);
-
-			expect(dropdown.showOptions).to.be.false;
-			sinon.assert.calledOnce(setValue);
-			sinon.assert.calledWith(setValue, options[1]);
-		});
+		sinon.assert.calledOnce(closeSpy);
+		sinon.assert.calledOnce(setValue);
+		sinon.assert.calledWith(setValue, options[1]);
 	});
 
 	it('should transform the item to a display name', (): void => {
@@ -120,16 +97,6 @@ describe('SelectComponent', () => {
 
 		sinon.assert.calledOnce(transformService.getValue);
 		sinon.assert.calledWith(transformService.getValue, option, transform);
-	});
-
-	it('should return a clone of the template', (): void => {
-		const template: any = {};
-		dropdown.template = template;
-
-		const clone: any = dropdown.newTemplate();
-
-		expect(clone).to.not.equal(template);
-		expect(clone).to.deep.equal(template);
 	});
 
 	it('should use an external template if one is specified', (): void => {

--- a/source/components/inputs/select/select.ts
+++ b/source/components/inputs/select/select.ts
@@ -1,6 +1,6 @@
 import { Component, Optional, Inject, Input, Output, ViewChild, ContentChild, AfterViewInit, TemplateRef } from '@angular/core';
 import { Observable } from 'rxjs';
-import { isArray, clone } from 'lodash';
+import { isArray } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
@@ -13,6 +13,7 @@ import { ComponentValidator } from '../../../services/componentValidator/compone
 import { FormComponent } from '../../form/form';
 import { BusyComponent } from '../../busy/busy';
 import { OffClickDirective } from '../../../behaviors/offClick/offClick';
+import { PopoutListComponent } from '../../popoutList/popoutList';
 
 @Component({
 	selector: 'rlSelect',
@@ -20,7 +21,7 @@ import { OffClickDirective } from '../../../behaviors/offClick/offClick';
 	inputs: validationInputs,
 	outputs: baseOutputs,
 	providers: [ComponentValidator],
-	directives: [BusyComponent, OffClickDirective],
+	directives: [BusyComponent, OffClickDirective, PopoutListComponent],
 })
 export class SelectComponent<T> extends ValidatedInputComponent<T> implements AfterViewInit {
 	@Input() options: T[] | Observable<T[]>;
@@ -31,10 +32,10 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 	@Input() externalTemplate: TemplateRef<any>;
 
 	@ViewChild(BusyComponent) busy: BusyComponent;
+	@ViewChild(PopoutListComponent) list: PopoutListComponent<T>;
 	@ContentChild(TemplateRef) template: TemplateRef<any>;
 
 	wrappedOptions: Observable<T[]>;
-	showOptions: boolean;
 	private transformService: __transform.ITransformService;
 
 	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService
@@ -57,26 +58,12 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 		this.busy.trigger(this.wrappedOptions);
 	}
 
-	toggle(): void {
-		this.showOptions = !this.showOptions;
-	}
-
-	close: { (): void } = () => {
-		if (this.showOptions) {
-			this.showOptions = false;
-		}
-	}
-
 	select(value: T): void {
 		this.setValue(value);
-		this.showOptions = false;
+		this.list.close();
 	}
 
 	getDisplayName(item: T): string {
 		return this.transformService.getValue(item, this.transform);
-	}
-
-	newTemplate(): TemplateRef<any> {
-		return clone(this.template);
 	}
 }

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -1,7 +1,7 @@
 <div class="field"
 	 [class.error]="!control.valid"
 	 (offClick)="close()">
-	<label class="label-slide angular-animate" [hidden]="!(search && label)">{{label}}</label>
+	<label class="label-slide angular-animate" [hidden]="hideFlowerup">{{label}}</label>
 	<div [hidden]="collapsed">
 		<input class="form-control rl-select-trigger"
 			   type="text"

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -1,7 +1,7 @@
 <div class="field"
 	 [class.error]="!control.valid"
 	 (offClick)="close()">
-	<label class="label-slide angular-animate" [hidden]="!(value && label)">{{label}}</label>
+	<label class="label-slide angular-animate" [hidden]="!(search && label)">{{label}}</label>
 	<div [hidden]="collapsed">
 		<input class="form-control rl-select-trigger"
 			   type="text"

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -1,0 +1,35 @@
+<div class="field"
+	 [class.error]="!control.valid"
+	 (offClick)="close()">
+	<label class="label-slide angular-animate" [hidden]="!(value && label)">{{label}}</label>
+	<div [hidden]="collapsed">
+		<input class="form-control rl-select-trigger"
+			   (click)="toggle()"
+			   [disabled]="disabled"
+			   [class.rl-select-open]="showOptions"
+			   [placeholder]="label"
+			   [value]="search"
+			   (input)="searchStream.next($event.target.value)" />
+		<ul class="rl-select-list" *ngIf="showOptions && search">
+			<li class="rl-select-option rl-select-option-custom" *ngIf="allowCustomOption" (click)="selectCustom">{{search}}</li>
+			<li class="rl-select-option"
+				*ngFor="let option of visibleItems | async"
+				(click)="selectItem(option)">
+				<span *ngIf="template">
+					<template [ngTemplateOutlet]="newTemplate()" [ngOutletContext]="{ $implicit: option }"></template>
+				</span>
+				<span *ngIf="!template">{{getDisplayName(option)}}</span>
+			</li>
+		</ul>
+	</div>
+	<div class="collapsed" [hidden]="!collapsed">
+		<span>{{getDisplayName(value)}}</span>
+		<rlButton type="default flat" (trigger)="clear()">
+			<i class="fa fa-remove"></i>
+		</rlButton>
+	</div>
+	<rlBusy></rlBusy>
+	<div [hidden]="control.valid" class="error-string">
+		{{componentValidator.error}}
+	</div>
+</div>

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -1,4 +1,4 @@
-<div class="field"
+<div class="field typeahead"
 	 [class.error]="!control.valid"
 	 (offClick)="close()">
 	<label class="label-slide angular-animate" [hidden]="hideFlowerup">{{label}}</label>

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -4,6 +4,7 @@
 	<label class="label-slide angular-animate" [hidden]="!(value && label)">{{label}}</label>
 	<div [hidden]="collapsed">
 		<input class="form-control rl-select-trigger"
+			   type="text"
 			   (click)="toggle()"
 			   [disabled]="disabled"
 			   [class.rl-select-open]="showOptions"

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -7,11 +7,11 @@
 			   type="text"
 			   (click)="toggle()"
 			   [disabled]="disabled"
-			   [class.rl-select-open]="showOptions"
+			   [class.rl-select-open]="showOptionsWrapper"
 			   [placeholder]="label"
 			   [value]="search"
 			   (input)="searchStream.next($event.target.value)" />
-		<ul class="rl-select-list" *ngIf="showOptions && search">
+		<ul class="rl-select-list" *ngIf="showOptionsWrapper">
 			<li class="rl-select-option rl-select-option-custom" *ngIf="allowCustomOption" (click)="selectCustom()">{{search}}</li>
 			<li class="rl-select-option"
 				*ngFor="let option of visibleItems | async"

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -1,27 +1,24 @@
 <div class="field typeahead"
 	 [class.error]="!control.valid"
-	 (offClick)="close()">
+	 (offClick)="list.close()">
 	<label class="label-slide angular-animate" [hidden]="hideFlowerup">{{label}}</label>
 	<div [hidden]="collapsed">
 		<input class="form-control rl-select-trigger"
 			   type="text"
-			   (click)="toggle()"
+			   (click)="list.toggle()"
 			   [disabled]="disabled"
-			   [class.rl-select-open]="showOptionsWrapper"
+			   [class.rl-select-open]="canShowOptions && list.showOptions"
 			   [placeholder]="label"
 			   [value]="search"
 			   (input)="searchStream.next($event.target.value)" />
-		<ul class="rl-select-list" *ngIf="showOptionsWrapper">
+		<rlPopoutList #list
+					  [hidden]="!canShowOptions"
+					  [options]="visibleItems"
+					  [template]="template"
+					  [transform]="transform"
+					  (select)="selectItem($event)">
 			<li class="rl-select-option rl-select-option-custom" *ngIf="allowCustomOption" (click)="selectCustom()">{{search}}</li>
-			<li class="rl-select-option"
-				*ngFor="let option of visibleItems | async"
-				(click)="selectItem(option)">
-				<span *ngIf="template">
-					<template [ngTemplateOutlet]="newTemplate()" [ngOutletContext]="{ $implicit: option }"></template>
-				</span>
-				<span *ngIf="!template">{{getDisplayName(option)}}</span>
-			</li>
-		</ul>
+		</rlPopoutList>
 	</div>
 	<div class="collapsed" [hidden]="!collapsed">
 		<span>{{getDisplayName(value)}}</span>

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -11,7 +11,7 @@
 			   [value]="search"
 			   (input)="searchStream.next($event.target.value)" />
 		<ul class="rl-select-list" *ngIf="showOptions && search">
-			<li class="rl-select-option rl-select-option-custom" *ngIf="allowCustomOption" (click)="selectCustom">{{search}}</li>
+			<li class="rl-select-option rl-select-option-custom" *ngIf="allowCustomOption" (click)="selectCustom()">{{search}}</li>
 			<li class="rl-select-option"
 				*ngFor="let option of visibleItems | async"
 				(click)="selectItem(option)">

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -228,6 +228,18 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.collapsed).to.be.true;
 		}));
 
+		it('should clear the current selection', (): void => {
+			typeahead.search = 'search';
+			typeahead.collapsed = true;
+
+			typeahead.clear();
+
+			sinon.assert.calledOnce(setValue);
+			sinon.assert.calledWith(setValue, null);
+			expect(typeahead.search).to.be.empty;
+			expect(typeahead.collapsed).to.be.false;
+		});
+
 		function initialLoad() {
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
 			typeahead.getItems = getItemsMock;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -62,10 +62,11 @@ describe('TypeaheadComponent', () => {
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
 			typeahead.getItems = getItemsMock;
 
-			typeahead.refresh('');
+			let visibleItems: string[];
+			typeahead.refresh('').subscribe(result => visibleItems = result);
 
 			sinon.assert.notCalled(getItemsMock);
-			expect(typeahead.visibleItems).to.be.empty;
+			expect(visibleItems).to.be.empty;
 
 			getItemsMock.flush();
 		}));
@@ -75,16 +76,17 @@ describe('TypeaheadComponent', () => {
 			let getItemsMock: __test.IMockedRequest<string[]> = mock.request([items[0], items[1]]);
 			typeahead.getItems = getItemsMock;
 
-			typeahead.refresh('Item ');
+			let visibleItems: string[];
+			typeahead.refresh('Item ').subscribe(result => visibleItems = result);
 
 			sinon.assert.calledOnce(getItemsMock);
 			sinon.assert.calledWith(getItemsMock, 'Item ');
 
 			getItemsMock.flush();
 
-			expect(typeahead.visibleItems.length).to.equal(2);
-			expect(typeahead.visibleItems[0]).to.equal(items[0]);
-			expect(typeahead.visibleItems[1]).to.equal(items[1]);
+			expect(visibleItems.length).to.equal(2);
+			expect(visibleItems[0]).to.equal(items[0]);
+			expect(visibleItems[1]).to.equal(items[1]);
 		}));
 
 		it('should apply the search string if useClientSearching is on', fakeAsync((): void => {
@@ -93,16 +95,17 @@ describe('TypeaheadComponent', () => {
 			let getItemsMock: __test.IMockedRequest<string[]> = mock.request(items);
 			typeahead.getItems = getItemsMock;
 
-			typeahead.refresh('A');
+			let visibleItems: string[];
+			typeahead.refresh('A').subscribe(result => visibleItems = result);
 
 			sinon.assert.calledOnce(getItemsMock);
 			expect(getItemsMock.firstCall.args).to.be.empty;
 
 			getItemsMock.flush();
 
-			expect(typeahead.visibleItems.length).to.equal(2);
-			expect(typeahead.visibleItems[0]).to.equal(items[2]);
-			expect(typeahead.visibleItems[1]).to.equal(items[3]);
+			expect(visibleItems.length).to.equal(2);
+			expect(visibleItems[0]).to.equal(items[2]);
+			expect(visibleItems[1]).to.equal(items[3]);
 		}));
 
 		it('should cache the results of the parent getItems function and apply searches aganst the cached data if useClientSearching is on'
@@ -111,19 +114,20 @@ describe('TypeaheadComponent', () => {
 
 				let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
 				typeahead.getItems = getItemsMock;
-				typeahead.refresh('A');
+				let visibleItems: string[];
+				typeahead.refresh('A').subscribe(result => visibleItems = result);
 				getItemsMock.flush();
 
 				getItemsMock.reset();
 
-				typeahead.refresh('2');
+				typeahead.refresh('2').subscribe(result => visibleItems = result);
 
 				flushMicrotasks();
 
 				sinon.assert.notCalled(getItemsMock);
 
-				expect(typeahead.visibleItems.length).to.equal(1);
-				expect(typeahead.visibleItems[0]).to.equal(items[1]);
+				expect(visibleItems.length).to.equal(1);
+				expect(visibleItems[0]).to.equal(items[1]);
 			}));
 
 		it('should set the search value', (): void => {
@@ -234,7 +238,7 @@ describe('TypeaheadComponent', () => {
 
 	describe('showOptions', (): void => {
 		it('should toggle the options', (): void => {
-			expect(typeahead.showOptions).to.be.undefined;
+			expect(typeahead.showOptions).to.be.false;
 
 			typeahead.toggle();
 
@@ -263,13 +267,13 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.showOptions).to.be.false;
 		});
 
-		it('should open the options when a search returns', (): void => {
+		it('should open the options when a search returns', fakeAsync((): void => {
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(['item']);
 			typeahead.getItems = getItemsMock;
 			typeahead.refresh('I');
 			getItemsMock.flush();
 
 			expect(typeahead.showOptions).to.be.true;
-		});
+		}));
 	});
 });

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -231,4 +231,36 @@ describe('TypeaheadComponent', () => {
 			getItemsMock.flush();
 		}
 	});
+
+	describe('showOptions', (): void => {
+		it('should toggle the options', (): void => {
+			expect(typeahead.showOptions).to.be.undefined;
+
+			typeahead.toggle();
+
+			expect(typeahead.showOptions).to.be.true;
+
+			typeahead.toggle();
+
+			expect(typeahead.showOptions).to.be.false;
+		});
+
+		it('should close the options', (): void => {
+			typeahead.showOptions = true;
+			typeahead.close();
+			expect(typeahead.showOptions).to.be.false;
+		});
+
+		it('should do nothing if the options are already closed', (): void => {
+			typeahead.showOptions = false;
+			typeahead.close();
+			expect(typeahead.showOptions).to.be.false;
+		});
+
+		it('should close the options when an item is selected', (): void => {
+			typeahead.showOptions = true;
+			typeahead.selectItem('option');
+			expect(typeahead.showOptions).to.be.false;
+		});
+	});
 });

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -90,7 +90,7 @@ describe('TypeaheadComponent', () => {
 		}));
 
 		it('should apply the search string if useClientSearching is on', fakeAsync((): void => {
-			typeahead.useClientSearching = true;
+			typeahead.clientSearch = true;
 
 			let getItemsMock: __test.IMockedRequest<string[]> = mock.request(items);
 			typeahead.getItems = getItemsMock;
@@ -110,7 +110,7 @@ describe('TypeaheadComponent', () => {
 
 		it('should cache the results of the parent getItems function and apply searches aganst the cached data if useClientSearching is on'
 			, fakeAsync((): void => {
-				typeahead.useClientSearching = true;
+				typeahead.clientSearch = true;
 
 				let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
 				typeahead.getItems = getItemsMock;
@@ -142,7 +142,7 @@ describe('TypeaheadComponent', () => {
 
 	describe('external API', (): void => {
 		it('should add the specified item to the cached item list', fakeAsync((): void => {
-			typeahead.useClientSearching = true;
+			typeahead.clientSearch = true;
 
 			let items: string[] = [];
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
@@ -159,7 +159,7 @@ describe('TypeaheadComponent', () => {
 		}));
 
 		it('should remove the specified item from the cached items list', fakeAsync((): void => {
-			typeahead.useClientSearching = true;
+			typeahead.clientSearch = true;
 
 			let items: string[] = ['Item 1'];
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
@@ -183,7 +183,7 @@ describe('TypeaheadComponent', () => {
 		it('should collapse if allowCollapse is turned on', fakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
 			typeahead.select = <any>{ emit: selectSpy };
-			typeahead.useClientSearching = true;
+			typeahead.clientSearch = true;
 			typeahead.allowCollapse = true;
 			initialLoad();
 
@@ -198,7 +198,7 @@ describe('TypeaheadComponent', () => {
 
 		it('should call the select function without collapsing', fakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
-			typeahead.useClientSearching = true;
+			typeahead.clientSearch = true;
 			typeahead.select = <any>{ emit: selectSpy };
 			initialLoad();
 
@@ -212,7 +212,7 @@ describe('TypeaheadComponent', () => {
 
 		it('should call create with the search text if the search option is selected', fakeAsync((): void => {
 			let createSpy: Sinon.SinonSpy = sinon.spy(search => { return { value: search }; });
-			typeahead.useClientSearching = true;
+			typeahead.clientSearch = true;
 			typeahead.allowCollapse = true;
 			typeahead.create = createSpy;
 			initialLoad();

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -125,23 +125,14 @@ describe('TypeaheadComponent', () => {
 				expect(typeahead.visibleItems[0]).to.equal(items[1]);
 			}));
 
-		it('should add a special search option to the list if a create handler is provided and no match is found', fakeAsync((): void => {
-			let createSpy: Sinon.SinonSpy = sinon.spy();
-			typeahead.useClientSearching = true;
-			typeahead.create = createSpy;
-
+		it('should set the search value', (): void => {
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
 			typeahead.getItems = getItemsMock;
 
 			typeahead.refresh('A');
 
-			getItemsMock.flush();
-
-			expect(typeahead.visibleItems.length).to.equal(3);
-			expect(typeahead.visibleItems[0].__isSearchOption).to.be.true;
-			expect(typeahead.visibleItems[1]).to.equal(items[2]);
-			expect(typeahead.visibleItems[2]).to.equal(items[3]);
-		}));
+			expect(typeahead.search).to.equal('A');
+		});
 	});
 
 	describe('external API', (): void => {

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -3,6 +3,7 @@ import __test = services.test;
 import mock = __test.mock;
 import fakeAsync = __test.fakeAsync;
 import flushMicrotasks = __test.flushMicrotasks;
+import __search = services.search;
 
 import { TypeaheadComponent } from './typeahead';
 
@@ -29,7 +30,7 @@ describe('TypeaheadComponent', () => {
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<any>(null, null, validator, null, null, null);
+		typeahead = new TypeaheadComponent<any>(null, null, validator, null, null, null, __search.searchUtility);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -182,45 +182,34 @@ describe('TypeaheadComponent', () => {
 			items = ['Item 1', 'Item 2', 'Another item', 'A fourth item'];
 		});
 
-		it('should collapse if no select handler is specified', fakeAsync((): void => {
-			typeahead.useClientSearching = true;
-			initialLoad();
-
-			typeahead.selection = items[0];
-
-			expect(typeahead.selection).to.equal(items[0]);
-			expect(typeahead.collapsed).to.be.true;
-		}));
-
-		it('should collapse if a select handler is provided and allowCollapse is turned on', fakeAsync((): void => {
+		it('should collapse if allowCollapse is turned on', fakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
+			typeahead.select = <any>{ emit: selectSpy };
 			typeahead.useClientSearching = true;
 			typeahead.allowCollapse = true;
-			typeahead.select = selectSpy;
 			initialLoad();
 
-			typeahead.selection = items[0];
+			typeahead.selectItem(items[0]);
 
-			expect(typeahead.selection).to.equal(items[0]);
-			expect(typeahead.collapsed).to.be.true;
-
+			sinon.assert.calledOnce(setValue);
+			sinon.assert.calledWith(setValue, items[0]);
 			sinon.assert.calledOnce(selectSpy);
-			expect(selectSpy.firstCall.args[0].value).to.equal(items[0]);
+			sinon.assert.calledWith(selectSpy, items[0]);
+			expect(typeahead.collapsed).to.be.true;
 		}));
 
 		it('should call the select function without collapsing', fakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
 			typeahead.useClientSearching = true;
-			typeahead.select = selectSpy;
+			typeahead.select = <any>{ emit: selectSpy };
 			initialLoad();
 
-			typeahead.selection = items[0];
+			typeahead.selectItem(items[0]);
 
-			expect(typeahead.selection).to.not.exist;
+			sinon.assert.notCalled(setValue);
 			expect(typeahead.collapsed).to.be.false;
-
 			sinon.assert.calledOnce(selectSpy);
-			expect(selectSpy.firstCall.args[0].value).to.equal(items[0]);
+			sinon.assert.calledWith(selectSpy, items[0]);
 		}));
 
 		it('should call create with the search text if the search option is selected', fakeAsync((): void => {
@@ -229,13 +218,13 @@ describe('TypeaheadComponent', () => {
 			typeahead.create = createSpy;
 			initialLoad();
 
-			typeahead._searchOption.text = 'search';
-			typeahead.selection = typeahead._searchOption;
+			typeahead.search = 'search';
+			typeahead.selectCustom();
 
 			sinon.assert.calledOnce(createSpy);
-			expect(createSpy.firstCall.args[0].value).to.equal('search');
-
-			expect(typeahead.selection.value).to.equal('search');
+			sinon.assert.calledWith(createSpy, 'search');
+			sinon.assert.calledOnce(setValue);
+			sinon.assert.calledWith(setValue, { value: 'search' });
 			expect(typeahead.collapsed).to.be.true;
 		}));
 

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -276,4 +276,14 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.showOptions).to.be.true;
 		}));
 	});
+
+	it('should return a clone of the template', (): void => {
+		const template: any = {};
+		typeahead.template = template;
+
+		const clone: any = typeahead.newTemplate();
+
+		expect(clone).to.not.equal(template);
+		expect(clone).to.deep.equal(template);
+	});
 });

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -292,6 +292,35 @@ describe('TypeaheadComponent', () => {
 
 			expect(typeahead.showOptions).to.be.true;
 		}));
+
+	describe('ngOnChanges', (): void => {
+		it('should update the search value on a value change', (): void => {
+			typeahead.getDisplayName = item => item;
+			typeahead.ngOnChanges({
+				value: <any>{ currentValue: 'search' },
+			});
+
+			expect(typeahead.search).to.equal('search');
+		});
+
+		it('should collapse the typeahead on a value change if a value is specified and collapse is enabled', (): void => {
+			typeahead.allowCollapse = true;
+			typeahead.ngOnChanges({
+				value: <any>{ currentValue: 'search' },
+			});
+
+			expect(typeahead.collapsed).to.be.true;
+		});
+
+		it('should uncollapse if the value changes to null', (): void => {
+			typeahead.allowCollapse = true;
+			typeahead.collapsed = true;
+			typeahead.ngOnChanges({
+				value: <any>{ currentValue: null },
+			});
+
+			expect(typeahead.collapsed).to.be.false;
+		});
 	});
 
 	it('should return a clone of the template', (): void => {

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -186,6 +186,7 @@ describe('TypeaheadComponent', () => {
 			typeahead.select = <any>{ emit: selectSpy };
 			typeahead.clientSearch = true;
 			typeahead.allowCollapse = true;
+			typeahead.getDisplayName = item => item;
 			initialLoad();
 
 			typeahead.selectItem(items[0]);
@@ -195,12 +196,14 @@ describe('TypeaheadComponent', () => {
 			sinon.assert.calledOnce(selectSpy);
 			sinon.assert.calledWith(selectSpy, items[0]);
 			expect(typeahead.collapsed).to.be.true;
+			expect(typeahead.search).to.equal(items[0]);
 		}));
 
 		it('should call the select function without collapsing', fakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
 			typeahead.clientSearch = true;
 			typeahead.select = <any>{ emit: selectSpy };
+			typeahead.search = 'search';
 			initialLoad();
 
 			typeahead.selectItem(items[0]);
@@ -209,6 +212,7 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.collapsed).to.be.false;
 			sinon.assert.calledOnce(selectSpy);
 			sinon.assert.calledWith(selectSpy, items[0]);
+			expect(typeahead.search).to.be.empty;
 		}));
 
 		it('should call create with the search text if the search option is selected', fakeAsync((): void => {

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -35,7 +35,7 @@ describe('TypeaheadComponent', () => {
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<any>(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility);
+		typeahead = new TypeaheadComponent<any>(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, <any>__search.searchUtility);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;
@@ -255,63 +255,21 @@ describe('TypeaheadComponent', () => {
 		}
 	});
 
-	describe('showOptions', (): void => {
-		it('should toggle the options', (): void => {
-			expect(typeahead.showOptions).to.be.false;
-
-			typeahead.toggle();
-
-			expect(typeahead.showOptions).to.be.true;
-
-			typeahead.toggle();
-
-			expect(typeahead.showOptions).to.be.false;
-		});
-
-		it('should close the options', (): void => {
-			typeahead.showOptions = true;
-			typeahead.close();
-			expect(typeahead.showOptions).to.be.false;
-		});
-
-		it('should do nothing if the options are already closed', (): void => {
-			typeahead.showOptions = false;
-			typeahead.close();
-			expect(typeahead.showOptions).to.be.false;
-		});
-
-		it('should close the options when an item is selected', (): void => {
-			typeahead.showOptions = true;
-			typeahead.selectItem('option');
-			expect(typeahead.showOptions).to.be.false;
-		});
-
-		it('should open the options when a search returns', fakeAsync((): void => {
-			let getItemsMock: __test.IMockedRequest<string> = mock.request(['item']);
-			typeahead.getItems = getItemsMock;
-			typeahead.refresh('I');
-			getItemsMock.flush();
-
-			expect(typeahead.showOptions).to.be.true;
-		}));
-
+	describe('canShowOptions', (): void => {
 		it('should return false if loading', (): void => {
 			typeahead.busy.loading = true;
-			typeahead.showOptions = true;
-			expect(typeahead.showOptionsWrapper).to.be.false;
+			expect(typeahead.canShowOptions).to.be.false;
 		});
 
 		it('should return false if search is empty', (): void => {
 			typeahead.search = '';
-			typeahead.showOptions = true;
-			expect(typeahead.showOptionsWrapper).to.be.false;
+			expect(typeahead.canShowOptions).to.be.false;
 		});
 
-		it('should return showOptions if not loading and a search is present', (): void => {
+		it('should return true if not loading and a search is present', (): void => {
 			typeahead.search = 'search';
 			typeahead.busy.loading = false;
-			typeahead.showOptions = true;
-			expect(typeahead.showOptionsWrapper).to.be.true;
+			expect(typeahead.canShowOptions).to.be.true;
 		});
 	});
 
@@ -343,15 +301,5 @@ describe('TypeaheadComponent', () => {
 
 			expect(typeahead.collapsed).to.be.false;
 		});
-	});
-
-	it('should return a clone of the template', (): void => {
-		const template: any = {};
-		typeahead.template = template;
-
-		const clone: any = typeahead.newTemplate();
-
-		expect(clone).to.not.equal(template);
-		expect(clone).to.deep.equal(template);
 	});
 });

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -4,6 +4,7 @@ import mock = __test.mock;
 import fakeAsync = __test.fakeAsync;
 import flushMicrotasks = __test.flushMicrotasks;
 import __object = services.object;
+import __array = services.array;
 import __guid = services.guid;
 import __search = services.search;
 
@@ -33,7 +34,7 @@ describe('TypeaheadComponent', () => {
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<any>(null, null, validator, __object.objectUtility, null, __guid.guid, __search.searchUtility);
+		typeahead = new TypeaheadComponent<any>(null, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -293,6 +293,26 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.showOptions).to.be.true;
 		}));
 
+		it('should return false if loading', (): void => {
+			typeahead.busy.loading = true;
+			typeahead.showOptions = true;
+			expect(typeahead.showOptionsWrapper).to.be.false;
+		});
+
+		it('should return false if search is empty', (): void => {
+			typeahead.search = '';
+			typeahead.showOptions = true;
+			expect(typeahead.showOptionsWrapper).to.be.false;
+		});
+
+		it('should return showOptions if not loading and a search is present', (): void => {
+			typeahead.search = 'search';
+			typeahead.busy.loading = false;
+			typeahead.showOptions = true;
+			expect(typeahead.showOptionsWrapper).to.be.true;
+		});
+	});
+
 	describe('ngOnChanges', (): void => {
 		it('should update the search value on a value change', (): void => {
 			typeahead.getDisplayName = item => item;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -209,6 +209,7 @@ describe('TypeaheadComponent', () => {
 		it('should call create with the search text if the search option is selected', fakeAsync((): void => {
 			let createSpy: Sinon.SinonSpy = sinon.spy(search => { return { value: search }; });
 			typeahead.useClientSearching = true;
+			typeahead.allowCollapse = true;
 			typeahead.create = createSpy;
 			initialLoad();
 

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -71,14 +71,13 @@ describe('TypeaheadComponent', () => {
 
 		it('should return the result of the getItems function if useClientSearching is off', fakeAsync((): void => {
 			// simulate a server-side search
-			let getItemsMock: __test.IMockedRequest<string[]> = mock.request([[items[0], items[1]]]);
+			let getItemsMock: __test.IMockedRequest<string[]> = mock.request([items[0], items[1]]);
 			typeahead.getItems = getItemsMock;
 
 			typeahead.refresh('Item ');
 
 			sinon.assert.calledOnce(getItemsMock);
-			let searchArg: string = getItemsMock.firstCall.args[0];
-			expect(searchArg).to.equal('Item ');
+			sinon.assert.calledWith(getItemsMock, 'Item ');
 
 			getItemsMock.flush();
 

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -186,7 +186,6 @@ describe('TypeaheadComponent', () => {
 			typeahead.select = <any>{ emit: selectSpy };
 			typeahead.clientSearch = true;
 			typeahead.allowCollapse = true;
-			typeahead.getDisplayName = item => item;
 			initialLoad();
 
 			typeahead.selectItem(items[0]);
@@ -196,14 +195,12 @@ describe('TypeaheadComponent', () => {
 			sinon.assert.calledOnce(selectSpy);
 			sinon.assert.calledWith(selectSpy, items[0]);
 			expect(typeahead.collapsed).to.be.true;
-			expect(typeahead.search).to.equal(items[0]);
 		}));
 
 		it('should call the select function without collapsing', fakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
 			typeahead.clientSearch = true;
 			typeahead.select = <any>{ emit: selectSpy };
-			typeahead.search = 'search';
 			initialLoad();
 
 			typeahead.selectItem(items[0]);
@@ -212,7 +209,6 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.collapsed).to.be.false;
 			sinon.assert.calledOnce(selectSpy);
 			sinon.assert.calledWith(selectSpy, items[0]);
-			expect(typeahead.search).to.be.empty;
 		}));
 
 		it('should call create with the search text if the search option is selected', fakeAsync((): void => {
@@ -233,15 +229,21 @@ describe('TypeaheadComponent', () => {
 		}));
 
 		it('should clear the current selection', (): void => {
-			typeahead.search = 'search';
 			typeahead.collapsed = true;
 
 			typeahead.clear();
 
 			sinon.assert.calledOnce(setValue);
 			sinon.assert.calledWith(setValue, null);
-			expect(typeahead.search).to.be.empty;
 			expect(typeahead.collapsed).to.be.false;
+		});
+
+		it('should clear the search value', (): void => {
+			typeahead.search = 'search';
+
+			typeahead.selectItem('item');
+
+			expect(typeahead.search).to.be.empty;
 		});
 
 		function initialLoad() {

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -19,7 +19,7 @@ interface IBusyMock {
 }
 
 describe('TypeaheadComponent', () => {
-	let typeahead: TypeaheadComponent;
+	let typeahead: TypeaheadComponent<any>;
 	let setValue: Sinon.SinonSpy;
 	let busy: IBusyMock;
 
@@ -29,7 +29,7 @@ describe('TypeaheadComponent', () => {
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<ITestOption>(null, null, validator, null, null, null);
+		typeahead = new TypeaheadComponent<any>(null, null, validator, null, null, null);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;
@@ -40,7 +40,7 @@ describe('TypeaheadComponent', () => {
 
 	it('should collapse on init if allowCollapse is specified and a model value is present', (): void => {
 		typeahead.allowCollapse = true;
-		typeahead.ngModel.$viewValue = 'Item';
+		typeahead.value = 'Item';
 		typeahead.ngOnInit();
 
 		expect(typeahead.collapsed).to.be.true;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -35,7 +35,7 @@ describe('TypeaheadComponent', () => {
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<any>(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, <any>__search.searchUtility);
+		typeahead = new TypeaheadComponent<any>(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -1,0 +1,249 @@
+import { services } from 'typescript-angular-utilities';
+import __test = services.test;
+import mock = __test.mock;
+import fakeAsync = __test.fakeAsync;
+import flushMicrotasks = __test.flushMicrotasks;
+
+import { TypeaheadComponent } from './typeahead';
+
+interface ITransformMock {
+	getValue: Sinon.SinonSpy;
+}
+
+interface ITestOption {
+	value: string;
+}
+
+interface IBusyMock {
+	trigger: Sinon.SinonSpy;
+}
+
+describe('TypeaheadComponent', () => {
+	let typeahead: TypeaheadComponent;
+	let setValue: Sinon.SinonSpy;
+	let busy: IBusyMock;
+
+	beforeEach(() => {
+		const validator: any = {
+			validate: sinon.spy(),
+			afterInit: sinon.spy(),
+		};
+
+		typeahead = new TypeaheadComponent<ITestOption>(null, null, validator, null, null, null);
+
+		setValue = sinon.spy();
+		typeahead.setValue = setValue;
+
+		busy = { trigger: sinon.spy() };
+		typeahead.busy = <any>busy;
+	});
+
+	it('should collapse on init if allowCollapse is specified and a model value is present', (): void => {
+		typeahead.allowCollapse = true;
+		typeahead.ngModel.$viewValue = 'Item';
+		typeahead.ngOnInit();
+
+		expect(typeahead.collapsed).to.be.true;
+	});
+
+	describe('loadItems', (): void => {
+		let items: string[];
+
+		beforeEach((): void => {
+			items = ['Item 1', 'Item 2', 'Another item', 'A fourth item'];
+		});
+
+		it('should return an empty list if no text is entered', fakeAsync((): void => {
+			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
+			typeahead.getItems = getItemsMock;
+
+			typeahead.refresh('');
+
+			sinon.assert.notCalled(getItemsMock);
+			expect(typeahead.visibleItems).to.be.empty;
+
+			getItemsMock.flush();
+		}));
+
+		it('should return the result of the getItems function if useClientSearching is off', fakeAsync((): void => {
+			// simulate a server-side search
+			let getItemsMock: __test.IMockedRequest<string[]> = mock.request([[items[0], items[1]]]);
+			typeahead.getItems = getItemsMock;
+
+			typeahead.refresh('Item ');
+
+			sinon.assert.calledOnce(getItemsMock);
+			let searchArg: string = getItemsMock.firstCall.args[0];
+			expect(searchArg).to.equal('Item ');
+
+			getItemsMock.flush();
+
+			expect(typeahead.visibleItems.length).to.equal(2);
+			expect(typeahead.visibleItems[0]).to.equal(items[0]);
+			expect(typeahead.visibleItems[1]).to.equal(items[1]);
+		}));
+
+		it('should apply the search string if useClientSearching is on', fakeAsync((): void => {
+			typeahead.useClientSearching = true;
+
+			let getItemsMock: __test.IMockedRequest<string[]> = mock.request(items);
+			typeahead.getItems = getItemsMock;
+
+			typeahead.refresh('A');
+
+			sinon.assert.calledOnce(getItemsMock);
+			expect(getItemsMock.firstCall.args).to.be.empty;
+
+			getItemsMock.flush();
+
+			expect(typeahead.visibleItems.length).to.equal(2);
+			expect(typeahead.visibleItems[0]).to.equal(items[2]);
+			expect(typeahead.visibleItems[1]).to.equal(items[3]);
+		}));
+
+		it('should cache the results of the parent getItems function and apply searches aganst the cached data if useClientSearching is on'
+			, fakeAsync((): void => {
+				typeahead.useClientSearching = true;
+
+				let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
+				typeahead.getItems = getItemsMock;
+				typeahead.refresh('A');
+				getItemsMock.flush();
+
+				getItemsMock.reset();
+
+				typeahead.refresh('2');
+
+				flushMicrotasks();
+
+				sinon.assert.notCalled(getItemsMock);
+
+				expect(typeahead.visibleItems.length).to.equal(1);
+				expect(typeahead.visibleItems[0]).to.equal(items[1]);
+			}));
+
+		it('should add a special search option to the list if a create handler is provided and no match is found', fakeAsync((): void => {
+			let createSpy: Sinon.SinonSpy = sinon.spy();
+			typeahead.useClientSearching = true;
+			typeahead.create = createSpy;
+
+			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
+			typeahead.getItems = getItemsMock;
+
+			typeahead.refresh('A');
+
+			getItemsMock.flush();
+
+			expect(typeahead.visibleItems.length).to.equal(3);
+			expect(typeahead.visibleItems[0].__isSearchOption).to.be.true;
+			expect(typeahead.visibleItems[1]).to.equal(items[2]);
+			expect(typeahead.visibleItems[2]).to.equal(items[3]);
+		}));
+	});
+
+	describe('external API', (): void => {
+		it('should add the specified item to the cached item list', fakeAsync((): void => {
+			typeahead.useClientSearching = true;
+
+			let items: string[] = [];
+			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
+			typeahead.getItems = getItemsMock;
+			typeahead.refresh('A');
+			getItemsMock.flush();
+
+			let newItem: string = 'New item';
+
+			typeahead.add(newItem);
+
+			expect(items.length).to.equal(1);
+			expect(items[0]).to.equal(newItem);
+		}));
+
+		it('should remove the specified item from the cached items list', fakeAsync((): void => {
+			typeahead.useClientSearching = true;
+
+			let items: string[] = ['Item 1'];
+			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
+			typeahead.getItems = getItemsMock;
+			typeahead.refresh('I');
+			getItemsMock.flush();
+
+			typeahead.remove(items[0]);
+
+			expect(items).to.be.empty;
+		}));
+	});
+
+	describe('select', (): void => {
+		let items: string[];
+
+		beforeEach((): void => {
+			items = ['Item 1', 'Item 2', 'Another item', 'A fourth item'];
+		});
+
+		it('should collapse if no select handler is specified', fakeAsync((): void => {
+			typeahead.useClientSearching = true;
+			initialLoad();
+
+			typeahead.selection = items[0];
+
+			expect(typeahead.selection).to.equal(items[0]);
+			expect(typeahead.collapsed).to.be.true;
+		}));
+
+		it('should collapse if a select handler is provided and allowCollapse is turned on', fakeAsync((): void => {
+			let selectSpy: Sinon.SinonSpy = sinon.spy();
+			typeahead.useClientSearching = true;
+			typeahead.allowCollapse = true;
+			typeahead.select = selectSpy;
+			initialLoad();
+
+			typeahead.selection = items[0];
+
+			expect(typeahead.selection).to.equal(items[0]);
+			expect(typeahead.collapsed).to.be.true;
+
+			sinon.assert.calledOnce(selectSpy);
+			expect(selectSpy.firstCall.args[0].value).to.equal(items[0]);
+		}));
+
+		it('should call the select function without collapsing', fakeAsync((): void => {
+			let selectSpy: Sinon.SinonSpy = sinon.spy();
+			typeahead.useClientSearching = true;
+			typeahead.select = selectSpy;
+			initialLoad();
+
+			typeahead.selection = items[0];
+
+			expect(typeahead.selection).to.not.exist;
+			expect(typeahead.collapsed).to.be.false;
+
+			sinon.assert.calledOnce(selectSpy);
+			expect(selectSpy.firstCall.args[0].value).to.equal(items[0]);
+		}));
+
+		it('should call create with the search text if the search option is selected', fakeAsync((): void => {
+			let createSpy: Sinon.SinonSpy = sinon.spy(search => { return { value: search }; });
+			typeahead.useClientSearching = true;
+			typeahead.create = createSpy;
+			initialLoad();
+
+			typeahead._searchOption.text = 'search';
+			typeahead.selection = typeahead._searchOption;
+
+			sinon.assert.calledOnce(createSpy);
+			expect(createSpy.firstCall.args[0].value).to.equal('search');
+
+			expect(typeahead.selection.value).to.equal('search');
+			expect(typeahead.collapsed).to.be.true;
+		}));
+
+		function initialLoad() {
+			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
+			typeahead.getItems = getItemsMock;
+
+			typeahead.refresh('A');
+			getItemsMock.flush();
+		}
+	});
+});

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -42,6 +42,10 @@ describe('TypeaheadComponent', () => {
 
 		busy = { trigger: sinon.spy() };
 		typeahead.busy = <any>busy;
+		typeahead.list = <any>{
+			open: sinon.spy(),
+			close: sinon.spy(),
+		};
 	});
 
 	it('should collapse on init if allowCollapse is specified and a model value is present', (): void => {

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -3,6 +3,8 @@ import __test = services.test;
 import mock = __test.mock;
 import fakeAsync = __test.fakeAsync;
 import flushMicrotasks = __test.flushMicrotasks;
+import __object = services.object;
+import __guid = services.guid;
 import __search = services.search;
 
 import { TypeaheadComponent } from './typeahead';
@@ -26,11 +28,12 @@ describe('TypeaheadComponent', () => {
 
 	beforeEach(() => {
 		const validator: any = {
+			setValidators: sinon.spy(),
 			validate: sinon.spy(),
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<any>(null, null, validator, null, null, null, __search.searchUtility);
+		typeahead = new TypeaheadComponent<any>(null, null, validator, __object.objectUtility, null, __guid.guid, __search.searchUtility);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -7,6 +7,7 @@ import __object = services.object;
 import __array = services.array;
 import __guid = services.guid;
 import __search = services.search;
+import __transform = services.transform;
 
 import { TypeaheadComponent } from './typeahead';
 
@@ -34,7 +35,7 @@ describe('TypeaheadComponent', () => {
 			afterInit: sinon.spy(),
 		};
 
-		typeahead = new TypeaheadComponent<any>(null, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility);
+		typeahead = new TypeaheadComponent<any>(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -262,5 +262,14 @@ describe('TypeaheadComponent', () => {
 			typeahead.selectItem('option');
 			expect(typeahead.showOptions).to.be.false;
 		});
+
+		it('should open the options when a search returns', (): void => {
+			let getItemsMock: __test.IMockedRequest<string> = mock.request(['item']);
+			typeahead.getItems = getItemsMock;
+			typeahead.refresh('I');
+			getItemsMock.flush();
+
+			expect(typeahead.showOptions).to.be.true;
+		});
 	});
 });

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+
+import { services } from 'typescript-angular-utilities';
+import __object = services.object;
+import __array = services.array;
+import __guid = services.guid;
+import __transform = services.transform;
+
+import { ValidatedInputComponent, validationInputs, baseOutputs } from '../validationInput';
+import { ComponentValidator } from '../../../services/componentValidator/componentValidator.service';
+import { FormComponent } from '../../form/form';
+import { BusyComponent } from '../../busy/busy';
+import { OffClickDirective } from '../../../behaviors/offClick/offClick';
+
+@Component({
+	selector: 'rlTypeahead',
+	template: require('./typeahead.html'),
+	inputs: validationInputs,
+	outputs: baseOutputs,
+	providers: [ComponentValidator],
+	directives: [BusyComponent, OffClickDirective]
+})
+export class TypeaheadComponent<T> extends ValidatedInputComponent<T> {
+	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService
+			, @Optional() rlForm: FormComponent
+			, componentValidator: ComponentValidator
+			, @Inject(__object.objectToken) object: __object.IObjectUtility
+			, @Inject(__array.arrayToken) array: __array.IArrayUtility
+			, @Inject(__guid.guidToken) guid: __guid.IGuidService) {}
+}

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -103,10 +103,9 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 			this.visibleItems = [];
 			return null;
 		}
-		this.loading = true;
-		return this.loadItems(search).do((): void => {
-			this.loading = false;
-		});
+		const loadRequest: Observable<T[]> = this.loadItems(search);
+		this.busy.trigger(loadRequest);
+		return loadRequest;
 	}
 
 	ngOnInit(): void {

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -58,6 +58,14 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	transformService: __transform.ITransformService;
 	searchUtility: __search.ISearchUtility;
 
+	get showOptionsWrapper(): boolean {
+		if (this.busy.loading || !this.search) {
+			return false;
+		} else {
+			return this.showOptions;
+		}
+	}
+
 	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService
 			, @Optional() rlForm: FormComponent
 			, componentValidator: ComponentValidator

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -157,6 +157,8 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 			this.search = this.getDisplayName(changes.value.currentValue);
 			if (changes.value.currentValue && this.allowCollapse) {
 				this.collapsed = true;
+			} else {
+				this.collapsed = false;
 			}
 		}
 	}

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -160,6 +160,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 				this.search = search;
 			})
 			.debounceTime(DEFAULT_SEARCH_DEBOUNCE)
+			.do(() => this.busy.trigger(false))
 			.distinctUntilChanged()
 			.switchMap(search => this.refresh(search))
 			.subscribe(() => null);

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -35,7 +35,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	@Input() transform: __transform.ITransform<T, string>;
 	@Input() getItems: { (search?: string): Promise<T[]> | Observable<T[]> };
 	@Input() prefix: string;
-	@Input() useClientSearching: boolean;
+	@Input() clientSearch: boolean;
 	@Input() allowCollapse: boolean;
 	@Input() create: { (value: string): T };
 	@Output() select: EventEmitter<T> = new EventEmitter<T>();
@@ -129,7 +129,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	ngOnInit(): void {
 		super.ngOnInit();
 
-		this.loadDelay = this.useClientSearching ? 100 : 500;
+		this.loadDelay = this.clientSearch ? 100 : 500;
 		this.prefix = this.prefix || 'Search for';
 		this.placeholder = this.label != null ? this.prefix + ' ' + this.label.toLowerCase() : 'Search';
 
@@ -160,7 +160,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 
 	loadItems(search: string): Observable<T[]> {
 		let itemsStream: Observable<T[]>;
-		if (!this.useClientSearching) {
+		if (!this.clientSearch) {
 			itemsStream = Observable.from(this.getItems(search));
 		} else {
 			itemsStream = this.getItemsClient()

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -1,6 +1,6 @@
-import { Component, Input, Output, EventEmitter, Inject, Optional, OnInit, OnChanges, SimpleChange, ViewChild } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Inject, Optional, OnInit, OnChanges, SimpleChange, ViewChild, ContentChild, TemplateRef } from '@angular/core';
 import { Observable, BehaviorSubject, Subject } from 'rxjs';
-import { find, filter } from 'lodash';
+import { find, filter, clone } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
@@ -41,6 +41,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	@Output() select: EventEmitter<T> = new EventEmitter<T>();
 
 	@ViewChild(BusyComponent) busy: BusyComponent;
+	@ContentChild(TemplateRef) template: TemplateRef<any>;
 
 	search: string;
 	searchStream: Subject<string> = new Subject<string>();
@@ -169,6 +170,10 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 				});
 		}
 		return itemsStream;
+	}
+
+	newTemplate(): TemplateRef<any> {
+		return clone(this.template);
 	}
 
 	private getItemsClient(): Observable<T[]> {

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -13,6 +13,7 @@ import { ValidatedInputComponent, validationInputs, baseOutputs } from '../valid
 import { ComponentValidator } from '../../../services/componentValidator/componentValidator.service';
 import { FormComponent } from '../../form/form';
 import { BusyComponent } from '../../busy/busy';
+import { ButtonComponent } from '../../buttons/index';
 import { OffClickDirective } from '../../../behaviors/offClick/offClick';
 
 export const DEFAULT_SEARCH_DEBOUNCE: number = 1000;
@@ -28,7 +29,7 @@ export interface ITypeaheadChanges {
 	inputs: validationInputs,
 	outputs: baseOutputs,
 	providers: [ComponentValidator],
-	directives: [BusyComponent, OffClickDirective]
+	directives: [BusyComponent, ButtonComponent, OffClickDirective]
 })
 export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements OnInit, OnChanges {
 	@Input() transform: __transform.ITransform<T, string>;

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -66,6 +66,10 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		}
 	}
 
+	get hideFlowerup(): boolean {
+		return !((this.search || this.value) && this.label);
+	}
+
 	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService
 			, @Optional() rlForm: FormComponent
 			, componentValidator: ComponentValidator
@@ -94,22 +98,19 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 
 	clear(): void {
 		this.setValue(null);
-		this.search = '';
 		this.collapsed = false;
 	}
 
 	selectItem(item: T): void {
 		this.showOptions = false;
+		this.search = '';
 
 		if (item != null) {
 			this.select.emit(item);
 
 			if (this.allowCollapse) {
 				this.collapsed = true;
-				this.search = this.getDisplayName(item);
 				this.setValue(item);
-			} else {
-				this.search = '';
 			}
 		}
 	}

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, Inject, Optional, OnInit, OnChanges, SimpleChange, ViewChild, ContentChild, TemplateRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Optional, OnInit, OnChanges, SimpleChange, ViewChild, ContentChild, TemplateRef } from '@angular/core';
 import { Observable, BehaviorSubject, Subject } from 'rxjs';
 import { find, filter } from 'lodash';
 
@@ -67,12 +67,12 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		return !((this.search || this.value) && this.label);
 	}
 
-	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService
+	constructor(transformService: __transform.TransformService
 			, @Optional() rlForm: FormComponent
 			, componentValidator: ComponentValidator
-			, @Inject(__object.objectToken) object: __object.IObjectUtility
-			, @Inject(__array.arrayToken) array: __array.IArrayUtility
-			, @Inject(__guid.guidToken) guid: __guid.IGuidService
+			, object: __object.ObjectUtility
+			, array: __array.ArrayUtility
+			, guid: __guid.GuidService
 			, searchService: __search.SearchUtility) {
 		super(rlForm, componentValidator, object, array, guid);
 		this.transformService = transformService;

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -52,7 +52,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	placeholder: string;
 	allowCustomOption: boolean;
 	collapsed: boolean = false;
-	showOptions: boolean;
+	showOptions: boolean = false;
 
 	transformService: __transform.ITransformService;
 	searchUtility: __search.ISearchUtility;

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -48,6 +48,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	placeholder: string;
 	allowCustomOption: boolean;
 	collapsed: boolean = false;
+	showOptions: boolean = false;
 
 	transformService: __transform.ITransformService;
 	searchUtility: __search.ISearchUtility;
@@ -83,6 +84,8 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	}
 
 	selectItem(item: T): void {
+		this.showOptions = false;
+
 		if (item != null) {
 			this.select.emit(item);
 
@@ -107,6 +110,14 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		const loadRequest: Observable<T[]> = this.loadItems(search);
 		this.busy.trigger(loadRequest);
 		return loadRequest;
+	}
+
+	toggle(): void {
+		this.showOptions = !this.showOptions;
+	}
+
+	close(): void {
+		this.showOptions = false;
 	}
 
 	ngOnInit(): void {

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -109,6 +109,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		}
 		const loadRequest: Observable<T[]> = this.loadItems(search);
 		this.busy.trigger(loadRequest);
+		loadRequest.subscribe(() => this.showOptions = true);
 		return loadRequest;
 	}
 

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -39,6 +39,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 
 	@ViewChild(BusyComponent) busy: BusyComponent;
 
+	search: string;
 	cachedItems: any[];
 	getItemsRequest: Observable<T[]>;
 	visibleItems: any[];
@@ -92,8 +93,8 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		}
 	}
 
-	selectCustom(text: string): void {
-		const newItem: T = this.create(text);
+	selectCustom(): void {
+		const newItem: T = this.create(this.search);
 		this.selectItem(newItem);
 	}
 

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -154,9 +154,14 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		}
 
 		this.searchStream
+			.do(search => {
+				this.busy.trigger(!this.object.isNullOrEmpty(search));
+				this.search = search;
+			})
 			.debounceTime(DEFAULT_SEARCH_DEBOUNCE)
 			.distinctUntilChanged()
-			.switchMap(search => this.refresh(search));
+			.switchMap(search => this.refresh(search))
+			.subscribe(() => null);
 	}
 
 	ngOnChanges(changes: ITypeaheadChanges): void {

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -99,6 +99,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	}
 
 	refresh(search: string): Observable<T[]> {
+		this.search = search;
 		if (this.object.isNullOrEmpty(search)) {
 			this.visibleItems = [];
 			return null;

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -69,6 +69,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 		this.transformService = transformService;
 		this.searchUtility = searchService;
 		this.inputType = 'typeahead';
+		this.search = '';
 	}
 
 	add(item: T): void {
@@ -85,6 +86,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 
 	clear(): void {
 		this.setValue(null);
+		this.search = '';
 		this.collapsed = false;
 	}
 
@@ -96,7 +98,10 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 
 			if (this.allowCollapse) {
 				this.collapsed = true;
+				this.search = this.getDisplayName(item);
 				this.setValue(item);
+			} else {
+				this.search = '';
 			}
 		}
 	}
@@ -149,6 +154,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	ngOnChanges(changes: ITypeaheadChanges): void {
 		super.ngOnChanges(changes);
 		if (changes.value) {
+			this.search = this.getDisplayName(changes.value.currentValue);
 			if (changes.value.currentValue && this.allowCollapse) {
 				this.collapsed = true;
 			}

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -64,7 +64,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 			, @Inject(__object.objectToken) object: __object.IObjectUtility
 			, @Inject(__array.arrayToken) array: __array.IArrayUtility
 			, @Inject(__guid.guidToken) guid: __guid.IGuidService
-			, @Inject(__search.searchToken) searchService: __search.ISearchUtility) {
+			, searchService: __search.SearchUtility) {
 		super(rlForm, componentValidator, object, array, guid);
 		this.transformService = transformService;
 		this.searchUtility = searchService;

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -1,16 +1,24 @@
-import { Component, Inject, Optional } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Inject, Optional, OnInit, OnChanges, SimpleChange, ViewChild } from '@angular/core';
+import { Observable, BehaviorSubject } from 'rxjs';
+import { find, filter } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
 import __array = services.array;
 import __guid = services.guid;
 import __transform = services.transform;
+import __search = services.search;
 
 import { ValidatedInputComponent, validationInputs, baseOutputs } from '../validationInput';
 import { ComponentValidator } from '../../../services/componentValidator/componentValidator.service';
 import { FormComponent } from '../../form/form';
 import { BusyComponent } from '../../busy/busy';
 import { OffClickDirective } from '../../../behaviors/offClick/offClick';
+
+export interface ITypeaheadChanges {
+	value: SimpleChange;
+	[key: string]: SimpleChange;
+}
 
 @Component({
 	selector: 'rlTypeahead',
@@ -20,13 +28,152 @@ import { OffClickDirective } from '../../../behaviors/offClick/offClick';
 	providers: [ComponentValidator],
 	directives: [BusyComponent, OffClickDirective]
 })
-export class TypeaheadComponent<T> extends ValidatedInputComponent<T> {
+export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements OnInit, OnChanges {
+	@Input() transform: __transform.ITransform<T, string>;
+	@Input() getItems: { (search?: string): Promise<T[]> | Observable<T[]> };
+	@Input() prefix: string;
+	@Input() useClientSearching: boolean;
+	@Input() allowCollapse: boolean;
+	@Input() create: { (value: string): T };
+	@Output() select: EventEmitter<T> = new EventEmitter<T>();
+
+	@ViewChild(BusyComponent) busy: BusyComponent;
+
+	cachedItems: any[];
+	getItemsRequest: Observable<T[]>;
+	visibleItems: any[];
+	loading: boolean = false;
+	loadDelay: number;
+	placeholder: string;
+	allowCustomOption: boolean;
+	collapsed: boolean = false;
+
+	transformService: __transform.ITransformService;
+	searchUtility: __search.ISearchUtility;
+
 	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService
 			, @Optional() rlForm: FormComponent
 			, componentValidator: ComponentValidator
 			, @Inject(__object.objectToken) object: __object.IObjectUtility
 			, @Inject(__array.arrayToken) array: __array.IArrayUtility
-			, @Inject(__guid.guidToken) guid: __guid.IGuidService) {
+			, @Inject(__guid.guidToken) guid: __guid.IGuidService
+			, @Inject(__search.searchToken) searchService: __search.ISearchUtility) {
 		super(rlForm, componentValidator, object, array, guid);
+		this.transformService = transformService;
+		this.searchUtility = searchService;
+		this.inputType = 'typeahead';
+	}
+
+	add(item: T): void {
+		if (this.cachedItems != null) {
+			this.cachedItems.push(item);
+		}
+	}
+
+	remove(item: T): void {
+		if (this.cachedItems != null) {
+			this.array.remove(this.cachedItems, item);
+		}
+	}
+
+	clear(): void {
+		this.setValue(null);
+		this.collapsed = false;
+	}
+
+	selectItem(item: T): void {
+		if (item != null) {
+			this.select.emit(item);
+
+			if (this.allowCollapse) {
+				this.collapsed = true;
+				this.setValue(item);
+			}
+		}
+	}
+
+	selectCustom(text: string): void {
+		const newItem: T = this.create(text);
+		this.selectItem(newItem);
+	}
+
+	refresh(search: string): Observable<T[]> {
+		if (this.object.isNullOrEmpty(search)) {
+			this.visibleItems = [];
+			return null;
+		}
+		this.loading = true;
+		return this.loadItems(search).do((): void => {
+			this.loading = false;
+		});
+	}
+
+	ngOnInit(): void {
+		super.ngOnInit();
+
+		this.loadDelay = this.useClientSearching ? 100 : 500;
+		this.prefix = this.prefix || 'Search for';
+		this.placeholder = this.label != null ? this.prefix + ' ' + this.label.toLowerCase() : 'Search';
+
+		this.allowCustomOption = !this.object.isNullOrEmpty(this.create);
+
+		if (this.allowCollapse && !this.object.isNullOrEmpty(this.value)) {
+			this.collapsed = true;
+		}
+	}
+
+	ngOnChanges(changes: ITypeaheadChanges): void {
+		super.ngOnChanges(changes);
+		if (changes.value) {
+			if (changes.value.currentValue && this.allowCollapse) {
+				this.collapsed = true;
+			}
+		}
+	}
+
+	getDisplayName(item: T): string {
+		return this.transformService.getValue(item, this.transform);
+	}
+
+	loadItems(search: string): Observable<T[]> {
+		if (!this.useClientSearching) {
+			return Observable.from(this.getItems(search))
+				.do((items: any[]): void => {
+					this.visibleItems = items;
+				});
+		} else {
+			return this.getItemsClient()
+				.do((items: any[]): void => {
+					this.visibleItems = this.filter(items, search);
+				});
+		}
+	}
+
+	private getItemsClient(): Observable<T[]> {
+		if (this.cachedItems != null) {
+			return new BehaviorSubject(this.cachedItems);
+		}
+		//when useClientSearching is enabled, the entire list is loaded and then filtered in-memory
+		//caching the promise prevents multiple API calls from being made to load the entire list
+		else if (this.getItemsRequest != null) {
+			return this.getItemsRequest;
+		}
+		else {
+			return this.getItemsRequest = Observable.from(this.getItems())
+				.do((items: T[]): T[] => {
+					return this.cachedItems = items;
+				});
+		}
+	}
+
+	private showCustomSearch(search: string): boolean {
+		return this.allowCustomOption
+			&& !find(this.visibleItems, (item: any): boolean => {
+			return this.getDisplayName(item) === search;
+		});
+	}
+
+	private filter(list: T[], search: string): T[] {
+		return filter(list, (item: T): boolean => { return this.searchUtility.tokenizedSearch(item, search); });
 	}
 }

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Inject, Optional } from '@angular/core';
 
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
@@ -26,5 +26,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> {
 			, componentValidator: ComponentValidator
 			, @Inject(__object.objectToken) object: __object.IObjectUtility
 			, @Inject(__array.arrayToken) array: __array.IArrayUtility
-			, @Inject(__guid.guidToken) guid: __guid.IGuidService) {}
+			, @Inject(__guid.guidToken) guid: __guid.IGuidService) {
+		super(rlForm, componentValidator, object, array, guid);
+	}
 }

--- a/source/components/popoutList/popoutList.html
+++ b/source/components/popoutList/popoutList.html
@@ -1,0 +1,11 @@
+<ul class="rl-select-list" *ngIf="showOptions">
+	<ng-content></ng-content>
+	<li class="rl-select-option"
+		*ngFor="let option of options | async"
+		(click)="select.emit(option)">
+		<span *ngIf="template">
+			<template [ngTemplateOutlet]="newTemplate()" [ngOutletContext]="{ $implicit: option }"></template>
+		</span>
+		<span *ngIf="!template">{{getDisplayName(option)}}</span>
+	</li>
+</ul>

--- a/source/components/popoutList/popoutList.tests.ts
+++ b/source/components/popoutList/popoutList.tests.ts
@@ -39,10 +39,10 @@ describe('PopoutListComponent', () => {
 			expect(list.showOptions).to.be.false;
 		});
 
-		it('should do nothing if the options are already closed', (): void => {
-			list.showOptions = false;
-			list.close();
-			expect(list.showOptions).to.be.false;
+		it('should open the options', (): void => {
+			list.showOptions = true;
+			list.open();
+			expect(list.showOptions).to.be.true;
 		});
 	});
 

--- a/source/components/popoutList/popoutList.tests.ts
+++ b/source/components/popoutList/popoutList.tests.ts
@@ -48,7 +48,7 @@ describe('PopoutListComponent', () => {
 
 	it('should transform the item to a display name', (): void => {
 		const option: any = { value: 3 };
-		const transform: string = x => x.value;
+		const transform: any = x => x.value;
 		list.transform = transform;
 
 		list.getDisplayName(option);

--- a/source/components/popoutList/popoutList.tests.ts
+++ b/source/components/popoutList/popoutList.tests.ts
@@ -1,0 +1,69 @@
+import { Observable } from 'rxjs';
+
+import { PopoutListComponent } from './popoutList';
+
+interface ITransformMock {
+	getValue: Sinon.SinonSpy;
+}
+
+describe('PopoutListComponent', () => {
+	let list: PopoutListComponent<string>;
+	let options: string[];
+	let transformService: ITransformMock;
+
+	beforeEach(() => {
+		transformService = { getValue: sinon.spy() };
+
+		list = new PopoutListComponent<string>(transformService);
+
+		options = ['Option 1', 'Option 2', 'Option 3'];
+		list.options = Observable.of(options);
+	});
+
+	describe('showOptions', (): void => {
+		it('should toggle the options', (): void => {
+			expect(list.showOptions).to.be.undefined;
+
+			list.toggle();
+
+			expect(list.showOptions).to.be.true;
+
+			list.toggle();
+
+			expect(list.showOptions).to.be.false;
+		});
+
+		it('should close the options', (): void => {
+			list.showOptions = true;
+			list.close();
+			expect(list.showOptions).to.be.false;
+		});
+
+		it('should do nothing if the options are already closed', (): void => {
+			list.showOptions = false;
+			list.close();
+			expect(list.showOptions).to.be.false;
+		});
+	});
+
+	it('should transform the item to a display name', (): void => {
+		const option: any = { value: 3 };
+		const transform: string = x => x.value;
+		list.transform = transform;
+
+		list.getDisplayName(option);
+
+		sinon.assert.calledOnce(transformService.getValue);
+		sinon.assert.calledWith(transformService.getValue, option, transform);
+	});
+
+	it('should return a clone of the template', (): void => {
+		const template: any = {};
+		list.template = template;
+
+		const clone: any = list.newTemplate();
+
+		expect(clone).to.not.equal(template);
+		expect(clone).to.deep.equal(template);
+	});
+});

--- a/source/components/popoutList/popoutList.ts
+++ b/source/components/popoutList/popoutList.ts
@@ -1,0 +1,41 @@
+import { Component, Input, Output, EventEmitter, TemplateRef, Inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { clone } from 'lodash';
+
+import { services } from 'typescript-angular-utilities';
+import __transform = services.transform;
+
+@Component({
+	selector: 'rlPopoutList',
+	template: require('./popoutList.html'),
+})
+export class PopoutListComponent<T> {
+	@Input() options: Observable<T>;
+	@Input() template: TemplateRef<any>;
+	@Input() transform: __transform.ITransform<T, string>;
+	@Output() select: EventEmitter<T> = new EventEmitter<T>();
+
+	showOptions: boolean;
+
+	transformService: __transform.ITransformService;
+
+	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService) {
+		this.transformService = transformService;
+	}
+
+	toggle(): void {
+		this.showOptions = !this.showOptions;
+	}
+
+	close(): void {
+		this.showOptions = false;
+	}
+
+	newTemplate(): TemplateRef<any> {
+		return clone(this.template);
+	}
+
+	getDisplayName(item: T): string {
+		return this.transformService.getValue(item, this.transform);
+	}
+}

--- a/source/components/popoutList/popoutList.ts
+++ b/source/components/popoutList/popoutList.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, TemplateRef, Inject } from '@angular/core';
+import { Component, Input, Output, EventEmitter, TemplateRef } from '@angular/core';
 import { Observable } from 'rxjs';
 import { clone } from 'lodash';
 
@@ -19,7 +19,7 @@ export class PopoutListComponent<T> {
 
 	transformService: __transform.ITransformService;
 
-	constructor(@Inject(__transform.transformToken) transformService: __transform.ITransformService) {
+	constructor(transformService: __transform.TransformService) {
 		this.transformService = transformService;
 	}
 

--- a/source/components/popoutList/popoutList.ts
+++ b/source/components/popoutList/popoutList.ts
@@ -27,6 +27,10 @@ export class PopoutListComponent<T> {
 		this.showOptions = !this.showOptions;
 	}
 
+	open(): void {
+		this.showOptions = true;
+	}
+
 	close(): void {
 		this.showOptions = false;
 	}

--- a/source/components/popoutList/popoutList.ts
+++ b/source/components/popoutList/popoutList.ts
@@ -10,7 +10,7 @@ import __transform = services.transform;
 	template: require('./popoutList.html'),
 })
 export class PopoutListComponent<T> {
-	@Input() options: Observable<T>;
+	@Input() options: Observable<T[]>;
 	@Input() template: TemplateRef<any>;
 	@Input() transform: __transform.ITransform<T, string>;
 	@Output() select: EventEmitter<T> = new EventEmitter<T>();


### PR DESCRIPTION
Implemented typeahead in angular 2. Like select, we're using our own custom dropdown list here. (Using the same classes) However, instead of the 'input' being just a toggle for the list, it's actually a textbox here. The list generally opens when a search opens, however, at the moment a completed search can still be opened/closed like a dropdown. (i.e., if a search was entered, you can click on the input again to reopen the same result list)
