### PR TITLE
Tidy up promise rejections

### DIFF
--- a/source/components/buttons/buttonAsync/buttonAsync.ng1.ts
+++ b/source/components/buttons/buttonAsync/buttonAsync.ng1.ts
@@ -12,7 +12,7 @@ export const controllerName: string = 'ButtonAsyncController';
 
 export interface IButtonBindings {
 	busy: boolean;
-	action(...params: any[]): angular.IPromise<any> | void;
+	action(...params: any[]): Promise<any> | void;
 	size: string;
 	type: string;
 	ngDisabled: boolean;
@@ -21,28 +21,32 @@ export interface IButtonBindings {
 export class ButtonAsyncController extends ButtonController {
 	// bindings
 	busy: boolean;
-	action: { (...params: any[]): angular.IPromise<any> | void };
+	action: { (...params: any[]): Promise<any> | void };
 
 	static $inject: string[] = [promiseServiceName];
 	constructor(private promiseUtility: IPromiseUtility) {
 		super();
 	}
 
-	trigger(): void {
+	trigger(): Promise<any> {
 		if (!this.busy) {
 			this.busy = true;
 
-			let result: angular.IPromise<any> = <angular.IPromise<any>>this.action();
+			let result: Promise<any> = <Promise<any>>this.action();
+
 			if (this.promiseUtility.isPromise(result)) {
-				result.then((): void => {
+				return result.then((): void => {
 					this.busy = false;
-				}).catch(() => {
+				}).catch((error) => {
 					this.busy = false;
+					throw error;
 				});
 			} else if (<any>result !== true) {
 				this.busy = false;
 			}
 		}
+
+		return null;
 	}
 }
 

--- a/source/components/multiStepIndicator/multiStepIndicator.tests.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.tests.ts
@@ -104,12 +104,15 @@ describe('MultiStepIndicatorComponent', () => {
     }));
 
     it('should clear the spinner when the promise rejects', fakeAsync((): void => {
-        let step: IStep = <any>{ onClick: mock.rejectedPromise() };
+        const fakeError = 'fakeError';
+        let step: IStep = <any>{ onClick: mock.rejectedPromise(fakeError) };
 
         msi.steps = <IConfiguredStep[]>[step];
         msi.ngOnInit();
 
-        msi.onClick(<IConfiguredStep>step);
+        msi.onClick(<IConfiguredStep>step).catch((error) => {
+            expect(error).to.equal(fakeError);
+        });
 
         expect((<IConfiguredStep>step).isLoading).to.be.true;
 

--- a/source/components/multiStepIndicator/multiStepIndicator.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.ts
@@ -42,7 +42,7 @@ export class MultiStepIndicatorComponent implements OnInit {
 		this.configureSteps();
 	}
 
-	onClick(step: IConfiguredStep): Promise<void> | void {
+	onClick(step: IConfiguredStep): Promise<void> {
 		if (!this.anyLoading()) {
 			step.isLoading = true;
 
@@ -50,6 +50,7 @@ export class MultiStepIndicatorComponent implements OnInit {
 				step.isLoading = false;
 			}).catch((error) => {
 				step.isLoading = false;
+				throw error;
 			});
 		}
 		return null;


### PR DESCRIPTION
Making sure errors do not get swallowed in MSI and buttonAsync.  Promise rejections need to be caught so the spinners can be stopped.  The errors then need to be rethrown, otherwise the promise chain will resolve from that point forward.  Unit tests were updated to ensure that the error is rethrown.
