### PR TITLE
Autosave ng2

### DIFF
--- a/bootstrapper/app.ts
+++ b/bootstrapper/app.ts
@@ -21,6 +21,7 @@ import { moduleName as formModuleName } from './forms/formsBootstrapper';
 import { moduleName as miscModuleName } from './misc/miscBootstrapper';
 import { moduleName as textModuleName } from './text/text';
 
+import { InputsBootstrapper } from './inputs/inputsNg2Bootstrapper';
 import { FormsBootstrapper } from './forms/formsNg2Bootstrapper';
 import { MsiBootstrapperComponent } from './msi/msiBootstrapper.ng2';
 import { CardsBootstrapper } from './cards/cardsNg2Bootstrapper';
@@ -54,6 +55,7 @@ angular.module(moduleName, [
 	textModuleName,
 ])
 	.component('tsBootstrapper', bootstrapper)
+	.directive('tsInputsBootstrapper', <any>upgradeAdapter.downgradeNg2Component(InputsBootstrapper))
 	.directive('tsFormsBootstrapper', <any>upgradeAdapter.downgradeNg2Component(FormsBootstrapper))
 	.directive('tsMsiBootstrapper', <any>upgradeAdapter.downgradeNg2Component(MsiBootstrapperComponent))
 	.directive('tsCardsBootstrapper', <any>upgradeAdapter.downgradeNg2Component(CardsBootstrapper))

--- a/bootstrapper/forms/formsNg2.html
+++ b/bootstrapper/forms/formsNg2.html
@@ -1,79 +1,29 @@
 <h3>Forms</h3>
 <h4><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/form/form.md">rlForm</a>:</h4>
+<h5>Form with validation</h5>
+<rlForm [save]="waitCallback">
+	<rlTextbox rlRequired="This is a required field" label="Required textbox" maxlength="10"></rlTextbox>
+	<rlValidationGroup [model]="rating" [validator]="validator">
+		<rlUserRating [(value)]="rating" [range]="3"></rlUserRating>
+	</rlValidationGroup>
+	<rlButtonSubmit>Submit</rlButtonSubmit>
+</rlForm>
 <h5>Form with two-way bindings</h5>
+<rlForm [save]="waitCallback">
+	<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
+	<rlButtonSubmit>Submit</rlButtonSubmit>
+</rlForm>
+<h5>Nested forms</h5>
 <rlForm #testForm [save]="saveTestForm">
+	<rlTextbox name="textbox1" label="Textbox in outer form"></rlTextbox>
 	<rlForm>
-		<rlCheckbox [(value)]="checked" label="Checkbox with 2-way binding"></rlCheckbox>
-		<rlRadioGroup [(value)]="selection" label="Spinner">
-			<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-			<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-			<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-		</rlRadioGroup>
-		<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
-		<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
-		<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
-		<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
-		<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
-		<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
-			<template let-option>#{{option.value}}</template>
-		</rlSelect>
-		<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
-		<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
-			<template let-option>Value - {{option.value}}</template>
-		</rlTypeahead>
-		<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
-		<rlTypeaheadList [(value)]="selections" label="Typeahead list" [getItems]="getOptions" clientSearch="true" transform="value"></rlTypeaheadList>
-		<rlTypeaheadList [(value)]="selections" label="Typeahead list with templates" [getItems]="getOptions" clientSearch="true" transform="value">
-			<div *rlListHeader class="col-xs-12">Other name</div>
-			<div *rlListItem="let option; let remove = remove">
-				<div class="col-xs-10">Value - {{option.value}}</div>
-				<div class="col-xs-2"><rlButtonAsync [action]="remove">Remove</rlButtonAsync></div>
-			</div>
-		</rlTypeaheadList>
-		<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
-		<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
-		<rlValidationGroup [model]="rating" [validator]="validator">
-			<rlUserRating [(value)]="rating" [range]="3"></rlUserRating>
-		</rlValidationGroup>
+		<rlTextbox name="textbox2" label="Textbox in nested form"></rlTextbox>
 	</rlForm>
 	<rlButtonSubmit>Submit</rlButtonSubmit>
-	{{checked}}
-	{{text}}
 </rlForm>
 <h5>Form with names</h5>
 <rlForm [save]="waitCallback">
-	<rlCheckbox name="checkbox1" label="Checkbox 1"></rlCheckbox>
-	<rlRadioGroup name="radio1">
-		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-	</rlRadioGroup>
 	<rlTextbox name="textbox1" label="Textbox 1" rlRequired="Required textbox"></rlTextbox>
-	<rlTextarea name="textarea1" label="Textarea 1" rlRequired="Required text area"></rlTextarea>
-	<rlSpinner name="spinner1" label="Spinner 1"></rlSpinner>
-	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
-	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
-	<rlDateTime name="dateTime1" label="DateTime"></rlDateTime>
-	<rlAbsoluteTime name="time1" label="AbsoluteTime"></rlAbsoluteTime>
-	<rlUserRating name="userRating1"></rlUserRating>
-	<rlButtonSubmit rightAligned="true">Submit right</rlButtonSubmit>
-</rlForm>
-<h5>Disabled form</h5>
-<rlForm [save]="waitCallback">
-	<rlCheckbox name="checkbox1" disabled="true" label="Checkbox 1"></rlCheckbox>
-	<rlRadioGroup name="radio1" disabled="true">
-		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-	</rlRadioGroup>
-	<rlTextbox name="textbox1" disabled="true" label="Textbox 1" rlRequired="This is a required field"></rlTextbox>
-	<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
-	<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
-	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
-	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
-	<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
-	<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
-	<rlUserRating name="userRating1" disabled="true"></rlUserRating>
 	<rlButtonSubmit rightAligned="true">Submit right</rlButtonSubmit>
 </rlForm>
 <h5>Broken validation</h5>

--- a/bootstrapper/forms/formsNg2.html
+++ b/bootstrapper/forms/formsNg2.html
@@ -26,6 +26,10 @@
 	<rlTextbox name="textbox1" label="Textbox 1" rlRequired="Required textbox"></rlTextbox>
 	<rlButtonSubmit rightAligned="true">Submit right</rlButtonSubmit>
 </rlForm>
+<h5>Autosave form</h5>
+<rlForm [save]="waitCallback" rlAutosave>
+	<rlTextbox name="textbox1" label="Autosave textbox" rlRequired="Required textbox"></rlTextbox>
+</rlForm>
 <h5>Broken validation</h5>
 <rlForm>
 	<rlTextbox [validator]="brokenValidator"></rlTextbox>

--- a/bootstrapper/forms/formsNg2.html
+++ b/bootstrapper/forms/formsNg2.html
@@ -27,6 +27,7 @@
 	<rlButtonSubmit rightAligned="true">Submit right</rlButtonSubmit>
 </rlForm>
 <h5>Autosave form</h5>
+<rlBusy [loading]="autosaveAction.saving || autosaveAction.complete"></rlBusy>
 <rlForm [save]="waitCallback" rlAutosave>
 	<rlTextbox name="textbox1" label="Autosave textbox" rlRequired="Required textbox"></rlTextbox>
 </rlForm>

--- a/bootstrapper/forms/formsNg2Bootstrapper.ts
+++ b/bootstrapper/forms/formsNg2Bootstrapper.ts
@@ -1,15 +1,18 @@
 import { Component, ViewChild } from '@angular/core';
 
+import { BusyComponent } from '../../source/components/busy/busy';
 import { FormComponent } from '../../source/components/form/form';
 import { BUTTON_DIRECTIVES } from '../../source/components/buttons/index';
 import { INPUT_DIRECTIVES } from '../../source/components/inputs/index';
 import { ValidationGroupComponent } from '../../source/components/validationGroup/validationGroup';
 import { AutosaveDirective } from '../../source/behaviors/autosave/autosave';
+import { AutosaveActionService } from '../../source/services/autosaveAction/autosaveAction.service';
 
 @Component({
 	selector: 'tsFormsBootstrapper',
 	template: require('./formsNg2.html'),
 	directives: [
+		BusyComponent,
 		FormComponent,
 		BUTTON_DIRECTIVES,
 		INPUT_DIRECTIVES,
@@ -25,7 +28,11 @@ export class FormsBootstrapper {
 
 	@ViewChild('testForm') testForm: FormComponent;
 
-	constructor() {
+	autosaveAction: AutosaveActionService;
+
+	constructor(autosaveAction: AutosaveActionService) {
+		this.autosaveAction = autosaveAction;
+
 		this.validator = {
 			validate: () => this.rating >= 3,
 			errorMessage: 'You must give at least 3 stars',

--- a/bootstrapper/forms/formsNg2Bootstrapper.ts
+++ b/bootstrapper/forms/formsNg2Bootstrapper.ts
@@ -4,6 +4,7 @@ import { FormComponent } from '../../source/components/form/form';
 import { BUTTON_DIRECTIVES } from '../../source/components/buttons/index';
 import { INPUT_DIRECTIVES } from '../../source/components/inputs/index';
 import { ValidationGroupComponent } from '../../source/components/validationGroup/validationGroup';
+import { AutosaveDirective } from '../../source/behaviors/autosave/autosave';
 
 @Component({
 	selector: 'tsFormsBootstrapper',
@@ -13,6 +14,7 @@ import { ValidationGroupComponent } from '../../source/components/validationGrou
 		BUTTON_DIRECTIVES,
 		INPUT_DIRECTIVES,
 		ValidationGroupComponent,
+		AutosaveDirective,
 	],
 })
 export class FormsBootstrapper {

--- a/bootstrapper/forms/formsNg2Bootstrapper.ts
+++ b/bootstrapper/forms/formsNg2Bootstrapper.ts
@@ -1,23 +1,9 @@
 import { Component, ViewChild } from '@angular/core';
-import * as moment from 'moment';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { filter } from 'lodash';
-
-import { services } from 'typescript-angular-utilities';
-import __timezone = services.timezone;
 
 import { FormComponent } from '../../source/components/form/form';
 import { BUTTON_DIRECTIVES } from '../../source/components/buttons/index';
 import { INPUT_DIRECTIVES } from '../../source/components/inputs/index';
 import { ValidationGroupComponent } from '../../source/components/validationGroup/validationGroup';
-
-export interface ITestItem {
-	value: number;
-}
-
-export interface ITestItem2 {
-	value: string;
-}
 
 @Component({
 	selector: 'tsFormsBootstrapper',
@@ -30,35 +16,14 @@ export interface ITestItem2 {
 	],
 })
 export class FormsBootstrapper {
-	checked: boolean;
 	text: string;
-	date: moment.Moment;
-	selection: ITestItem;
 	rating: number;
-	time: string;
 	validator: any;
 	brokenValidator: any;
 
-	options: ITestItem[];
-	optionsAsync: Observable<ITestItem[]>;
-	typeaheadOptions: ITestItem2[];
-	selections: ITestItem2[];
-
 	@ViewChild('testForm') testForm: FormComponent;
 
-	constructor(timezoneService: __timezone.TimezoneService) {
-		timezoneService.setCurrentTimezone('-05:00');
-
-		this.text = 'Something is already entered';
-		this.options = [
-			{ value: 1 },
-			{ value: 2 },
-			{ value: 3 },
-		];
-		this.selection = this.options[0];
-		this.optionsAsync = this.wait(this.options);
-		this.time = '8:00AM';
-
+	constructor() {
 		this.validator = {
 			validate: () => this.rating >= 3,
 			errorMessage: 'You must give at least 3 stars',
@@ -67,22 +32,6 @@ export class FormsBootstrapper {
 			validate: () => false,
 			errorMessage: null,
 		};
-
-		this.typeaheadOptions = [
-			{ value: 'Option 1' },
-			{ value: 'Option 2' },
-			{ value: 'Option 3' },
-			{ value: 'Option 4' },
-			{ value: 'Option 5' },
-		];
-
-		this.selections = [this.typeaheadOptions[0], this.typeaheadOptions[2]]
-	}
-
-	wait(data: any): Observable<any> {
-		const subject: BehaviorSubject<ITestItem[]> = new BehaviorSubject<ITestItem[]>([]);
-		setTimeout(() => subject.next(data), 1000);
-		return subject.asObservable();
 	}
 
 	waitCallback: { (data: any): Promise<void> } = (data: any) => {
@@ -99,21 +48,5 @@ export class FormsBootstrapper {
 			return this.waitCallback(data);
 		}
 		return false;
-	}
-
-	getOptions = (): Observable<any> => {
-		return Observable.of(this.typeaheadOptions);
-	}
-
-	searchOptions = (search: string): Observable<any> => {
-		return this.wait(filter(this.typeaheadOptions, option => option.value.search(search) != -1));
-	}
-
-	createOption = (text: string): any => {
-		return { value: text };
-	}
-
-	log(value: any): void {
-		console.log(value);
 	}
 }

--- a/bootstrapper/inputs/inputBootstrapper.ts
+++ b/bootstrapper/inputs/inputBootstrapper.ts
@@ -99,9 +99,7 @@ function InputRoute($stateProvider) {
 		})
 		.state('inputs.ng2', {
 			url: '/ng2',
-			template: require('./inputsNg2.html'),
-			controller: 'InputTestController',
-			controllerAs: 'input',
+			template: '<ts-inputs-bootstrapper></ts-inputs-bootstrapper>',
 		});
 }
 

--- a/bootstrapper/inputs/inputsNg1.html
+++ b/bootstrapper/inputs/inputsNg1.html
@@ -1,18 +1,18 @@
-<h3><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/input/input.md">Inputs</a></h3>
+<h3><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/inputs/input.md">Inputs</a></h3>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/inputs/textbox/textbox.md">Textbox</a>:</label>
 	<rl-textbox ng-model="input.otherText" ></rl-textbox>
 </div>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textarea/textarea.md">Textarea</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/inputs/textarea/textarea.md">Textarea</a>:</label>
 	<rl-textarea ng-model="input.textAreaText"></rl-textarea>
 </div>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/spinner/spinner.md">Spinner</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/spinner/spinner.md">Spinner</a>:</label>
 	<rl-spinner ng-model="input.number"></rl-spinner>
 </div>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/dateTime/dateTime.md">Datetime</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/dateTime/dateTime.md">Datetime</a>:</label>
 	<rl-date-time ng-model="input.date" use-date="false"></rl-date-time>
 	<rl-date-time ng-model="input.date" use-time="false"></rl-date-time>
 	<rl-date-time ng-model="input.date"></rl-date-time>
@@ -20,7 +20,7 @@
 	<rl-button action="input.logDates()">Log dates</rl-button>
 </div>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/select/select.md">Select</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/select/select.md">Select</a>:</label>
 	<rl-select ng-model="input.dropdownSelection" get-options="input.getOptions()" transform="'name'" null-option="None"></rl-select>
 	<rl-select ng-model="input.dropdownSelection" get-options="input.getOptions()" transform="'name'">
 		<div class="row">
@@ -33,7 +33,7 @@
 	</rl-select>
 </div>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/typeahead/typeahead.md">Typeahead</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/typeahead/typeahead.md">Typeahead</a>:</label>
 	<rl-typeahead get-items="input.getOptions()" ng-model="input.selection" transform="'name'"
 					create="input.create(value)" label="Test create"></rl-typeahead>
 	<rl-typeahead get-items="input.getOptions()" ng-model="input.any" transform="'name'" use-client-searching="true"
@@ -52,13 +52,13 @@
 </div>
 
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/checkbox/checkbox.md">Checkbox</a>:</label>
 	<rl-checkbox ng-model="input.checked">Checkbox</rl-checkbox>
 	<div>Value: {{input.checked}}</div>
 </div>
 
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/radio/radio.md">Radio buttons</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/radio/radio.md">Radio buttons</a>:</label>
 	<div>
 		<rl-radio-group ng-model="input.radio1">
 			<rl-radio value="{ value: 1 }">1</rl-radio>

--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -1,15 +1,58 @@
 <h3><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/input/input.md">Angular 2 Inputs</a></h3>
-<div>
+<rlForm>
+	<div>
+		<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
+		<div><rlCheckbox [(value)]="checked" label="Checkbox with 2-way binding"></rlCheckbox></div>
+		<div><rlCheckbox value="false" [active]="false" label="Inactive"></rlCheckbox></div>
+		<div><rlCheckbox [active]="true" label="Disabled"></rlCheckbox></div>
+		<div><rlCheckbox (change)="log($event)" label="Output event"></rlCheckbox></div>
+		<div>Value: {{checked}}</div>
+	</div>
+	<rlRadioGroup [(value)]="selection" label="Spinner">
+		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
+		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
+		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
+	</rlRadioGroup>
 	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
-	<rl-textbox-ng></rl-textbox-ng>
-</div>
-<div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
-	<div><rl-checkbox-ng [(value)]="input.checked" label="Two-way bound"></rl-checkbox-ng></div>
-	<div><rl-checkbox-ng value="true" label="Initial value"></rl-checkbox-ng></div>
-	<div><rl-checkbox-ng value="false" [active]="false" label="Inactive"></rl-checkbox-ng></div>
-	<div><rl-checkbox-ng disabled="true" label="Disabled"></rl-checkbox-ng></div>
-	<div><rl-checkbox-ng (change)="input.log($event)" label="Output event"></rl-checkbox-ng></div>
-	<div>Value: {{input.checked}}</div>
-	<div><rl-absolute-time></rl-absolute-time></div>
-</div>
+	<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
+	<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
+	<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
+	<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
+	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
+	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
+		<template let-option>#{{option.value}}</template>
+	</rlSelect>
+	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
+	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
+	<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
+		<template let-option>Value - {{option.value}}</template>
+	</rlTypeahead>
+	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
+	<rlTypeaheadList [(value)]="selections" label="Typeahead list" [getItems]="getOptions" clientSearch="true" transform="value"></rlTypeaheadList>
+	<rlTypeaheadList [(value)]="selections" label="Typeahead list with templates" [getItems]="getOptions" clientSearch="true" transform="value">
+		<div *rlListHeader class="col-xs-12">Other name</div>
+		<div *rlListItem="let option; let remove = remove">
+			<div class="col-xs-10">Value - {{option.value}}</div>
+			<div class="col-xs-2"><rlButtonAsync [action]="remove">Remove</rlButtonAsync></div>
+		</div>
+	</rlTypeaheadList>
+	<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
+	<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
+</rlForm>
+<h5>Disabled inputs</h5>
+<rlForm>
+	<rlCheckbox name="checkbox1" disabled="true" label="Checkbox 1"></rlCheckbox>
+	<rlRadioGroup name="radio1" disabled="true">
+		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
+		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
+		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
+	</rlRadioGroup>
+	<rlTextbox name="textbox1" disabled="true" label="Textbox 1" rlRequired="This is a required field"></rlTextbox>
+	<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
+	<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
+	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
+	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
+	<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
+	<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
+	<rlUserRating name="userRating1" disabled="true"></rlUserRating>
+</rlForm>

--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -7,49 +7,87 @@
 	<div><rlCheckbox (change)="log($event)" label="Output event"></rlCheckbox></div>
 	<div>Value: {{checked}}</div>
 </div>
-<rlRadioGroup [(value)]="selection" label="Spinner">
-	<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-	<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-	<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-</rlRadioGroup>
-<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
-<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
-<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
-<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
-<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
-<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
-<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
-	<template let-option>#{{option.value}}</template>
-</rlSelect>
-<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
-<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
-<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
-	<template let-option>Value - {{option.value}}</template>
-</rlTypeahead>
-<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
-<rlTypeaheadList [(value)]="selections" label="Typeahead list" [getItems]="getOptions" clientSearch="true" transform="value"></rlTypeaheadList>
-<rlTypeaheadList [(value)]="selections" label="Typeahead list with templates" [getItems]="getOptions" clientSearch="true" transform="value">
-	<div *rlListHeader class="col-xs-12">Other name</div>
-	<div *rlListItem="let option; let remove = remove">
-		<div class="col-xs-10">Value - {{option.value}}</div>
-		<div class="col-xs-2"><rlButtonAsync [action]="remove">Remove</rlButtonAsync></div>
-	</div>
-</rlTypeaheadList>
-<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
-<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
+<div>
+	<rlRadioGroup [(value)]="selection" label="Spinner">
+		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
+		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
+		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
+	</rlRadioGroup>
+</div>
+<div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
+	<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
+	<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
+</div>
+<div>
+	<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
+</div>
+<div>
+	<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
+</div>
+<div>
+	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
+	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
+		<template let-option>#{{option.value}}</template>
+	</rlSelect>
+	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
+</div>
+<div>
+	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
+	<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
+		<template let-option>Value - {{option.value}}</template>
+	</rlTypeahead>
+	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
+</div>
+<div>
+	<rlTypeaheadList [(value)]="selections" label="Typeahead list" [getItems]="getOptions" clientSearch="true" transform="value"></rlTypeaheadList>
+	<rlTypeaheadList [(value)]="selections" label="Typeahead list with templates" [getItems]="getOptions" clientSearch="true" transform="value">
+		<div *rlListHeader class="col-xs-12">Other name</div>
+		<div *rlListItem="let option; let remove = remove">
+			<div class="col-xs-10">Value - {{option.value}}</div>
+			<div class="col-xs-2"><rlButtonAsync [action]="remove">Remove</rlButtonAsync></div>
+		</div>
+	</rlTypeaheadList>
+</div>
+<div>
+	<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
+</div>
+<div>
+	<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
+</div>
 
 <h5>Disabled inputs</h5>
-<rlCheckbox name="checkbox1" disabled="true" label="Checkbox 1"></rlCheckbox>
-<rlRadioGroup name="radio1" disabled="true">
-	<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-	<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-	<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-</rlRadioGroup>
-<rlTextbox name="textbox1" disabled="true" label="Textbox 1" rlRequired="This is a required field"></rlTextbox>
-<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
-<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
-<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
-<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
-<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
-<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
-<rlUserRating name="userRating1" disabled="true"></rlUserRating>
+<div>
+	<rlCheckbox name="checkbox1" disabled="true" label="Checkbox 1"></rlCheckbox>
+</div>
+<div>
+	<rlRadioGroup name="radio1" disabled="true">
+		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
+		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
+		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
+	</rlRadioGroup>
+</div>
+<div>
+	<rlTextbox name="textbox1" disabled="true" label="Textbox 1" rlRequired="This is a required field"></rlTextbox>
+</div>
+<div>
+	<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
+</div>
+<div>
+	<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
+</div>
+<div>
+	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
+</div>
+<div>
+	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
+</div>
+<div>
+	<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
+</div>
+<div>
+	<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
+</div>
+<div>
+	<rlUserRating name="userRating1" disabled="true"></rlUserRating>
+</div>

--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -1,6 +1,6 @@
-<h3><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/input/input.md">Angular 2 Inputs</a></h3>
+<h3><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/inputs/input.md">Angular 2 Inputs</a></h3>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/checkbox/checkbox.md">Checkbox</a>:</label>
 	<div><rlCheckbox [(value)]="checked" label="Checkbox with 2-way binding"></rlCheckbox></div>
 	<div><rlCheckbox value="false" [active]="false" label="Inactive"></rlCheckbox></div>
 	<div><rlCheckbox [disabled]="true" label="Disabled"></rlCheckbox></div>
@@ -8,6 +8,7 @@
 	<div>Value: {{checked}}</div>
 </div>
 <div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/radio/radio.md">Radio buttons</a>:</label>
 	<rlRadioGroup [(value)]="selection" label="Spinner">
 		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
 		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
@@ -15,17 +16,20 @@
 	</rlRadioGroup>
 </div>
 <div>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/inputs/textbox/textbox.md">Textbox</a>:</label>
 	<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
 	<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
 </div>
 <div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/inputs/textarea/textarea.md">Textarea</a>:</label>
 	<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
 </div>
 <div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/spinner/spinner.md">Spinner</a>:</label>
 	<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
 </div>
 <div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/select/select.md">Select</a>:</label>
 	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
 	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
 		<template let-option>#{{option.value}}</template>
@@ -33,6 +37,7 @@
 	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
 </div>
 <div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/typeahead/typeahead.md">Typeahead</a>:</label>
 	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
 	<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
 		<template let-option>Value - {{option.value}}</template>

--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -1,58 +1,55 @@
 <h3><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/input/input.md">Angular 2 Inputs</a></h3>
-<rlForm>
-	<div>
-		<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
-		<div><rlCheckbox [(value)]="checked" label="Checkbox with 2-way binding"></rlCheckbox></div>
-		<div><rlCheckbox value="false" [active]="false" label="Inactive"></rlCheckbox></div>
-		<div><rlCheckbox [active]="true" label="Disabled"></rlCheckbox></div>
-		<div><rlCheckbox (change)="log($event)" label="Output event"></rlCheckbox></div>
-		<div>Value: {{checked}}</div>
+<div>
+	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
+	<div><rlCheckbox [(value)]="checked" label="Checkbox with 2-way binding"></rlCheckbox></div>
+	<div><rlCheckbox value="false" [active]="false" label="Inactive"></rlCheckbox></div>
+	<div><rlCheckbox [active]="true" label="Disabled"></rlCheckbox></div>
+	<div><rlCheckbox (change)="log($event)" label="Output event"></rlCheckbox></div>
+	<div>Value: {{checked}}</div>
+</div>
+<rlRadioGroup [(value)]="selection" label="Spinner">
+	<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
+	<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
+	<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
+</rlRadioGroup>
+<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
+<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
+<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
+<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
+<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
+<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
+<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
+	<template let-option>#{{option.value}}</template>
+</rlSelect>
+<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
+<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
+<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
+	<template let-option>Value - {{option.value}}</template>
+</rlTypeahead>
+<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
+<rlTypeaheadList [(value)]="selections" label="Typeahead list" [getItems]="getOptions" clientSearch="true" transform="value"></rlTypeaheadList>
+<rlTypeaheadList [(value)]="selections" label="Typeahead list with templates" [getItems]="getOptions" clientSearch="true" transform="value">
+	<div *rlListHeader class="col-xs-12">Other name</div>
+	<div *rlListItem="let option; let remove = remove">
+		<div class="col-xs-10">Value - {{option.value}}</div>
+		<div class="col-xs-2"><rlButtonAsync [action]="remove">Remove</rlButtonAsync></div>
 	</div>
-	<rlRadioGroup [(value)]="selection" label="Spinner">
-		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-	</rlRadioGroup>
-	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/blob/master/source/components/textbox/textbox.md">Textbox</a>:</label>
-	<rlTextbox [(value)]="text" label="Textbox with 2-way binding"></rlTextbox>
-	<rlTextbox rlRequired="This is a required field" label="Textbox" maxlength="10"></rlTextbox>
-	<rlTextarea [(value)]="text" label="Textarea" rlRequired="This is a required field" rows="3" maxlength="10"></rlTextarea>
-	<rlSpinner [(value)]="number" label="Spinner" roundToStep="true" step="3.65" decimals="2" prefix="$" postfix="/hr"></rlSpinner>
-	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value"></rlSelect>
-	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
-		<template let-option>#{{option.value}}</template>
-	</rlSelect>
-	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
-	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead collapsable" [getItems]="searchOptions" transform="value" allowCollapse="true"></rlTypeahead>
-	<rlTypeahead (select)="log($event)" prefix="Search for a" label="Typeahead client searching" [getItems]="getOptions" clientSearch="true" transform="value">
-		<template let-option>Value - {{option.value}}</template>
-	</rlTypeahead>
-	<rlTypeahead [(value)]="typeaheadSelection" prefix="Search for a" label="Typeahead with create" [getItems]="getOptions" clientSearch="true" transform="value" [create]="createOption" allowCollapse="true"></rlTypeahead>
-	<rlTypeaheadList [(value)]="selections" label="Typeahead list" [getItems]="getOptions" clientSearch="true" transform="value"></rlTypeaheadList>
-	<rlTypeaheadList [(value)]="selections" label="Typeahead list with templates" [getItems]="getOptions" clientSearch="true" transform="value">
-		<div *rlListHeader class="col-xs-12">Other name</div>
-		<div *rlListItem="let option; let remove = remove">
-			<div class="col-xs-10">Value - {{option.value}}</div>
-			<div class="col-xs-2"><rlButtonAsync [action]="remove">Remove</rlButtonAsync></div>
-		</div>
-	</rlTypeaheadList>
-	<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
-	<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
-</rlForm>
+</rlTypeaheadList>
+<rlDateTime [(value)]="date" label="DateTime"></rlDateTime>
+<rlAbsoluteTime [(value)]="time" label="AbsoluteTime"></rlAbsoluteTime>
+
 <h5>Disabled inputs</h5>
-<rlForm>
-	<rlCheckbox name="checkbox1" disabled="true" label="Checkbox 1"></rlCheckbox>
-	<rlRadioGroup name="radio1" disabled="true">
-		<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
-		<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
-		<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
-	</rlRadioGroup>
-	<rlTextbox name="textbox1" disabled="true" label="Textbox 1" rlRequired="This is a required field"></rlTextbox>
-	<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
-	<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
-	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
-	<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
-	<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
-	<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
-	<rlUserRating name="userRating1" disabled="true"></rlUserRating>
-</rlForm>
+<rlCheckbox name="checkbox1" disabled="true" label="Checkbox 1"></rlCheckbox>
+<rlRadioGroup name="radio1" disabled="true">
+	<rlRadio label="Option 1" [option]="options[0]"></rlRadio>
+	<rlRadio label="Option 2" [option]="options[1]"></rlRadio>
+	<rlRadio label="Option 3" [option]="options[2]"></rlRadio>
+</rlRadioGroup>
+<rlTextbox name="textbox1" disabled="true" label="Textbox 1" rlRequired="This is a required field"></rlTextbox>
+<rlTextarea name="textarea1" disabled="true" label="Textarea 1" rlRequired="This is a required field"></rlTextarea>
+<rlSpinner name="spinner1" label="Spinner 1" disabled="true" prefix="$" postfix="/hr"></rlSpinner>
+<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" disabled="true"></rlSelect>
+<rlTypeahead name="typeahead1" prefix="Search for a" label="Typeahead" [getItems]="searchOptions" transform="value" allowCollapse="true" disabled="true"></rlTypeahead>
+<rlDateTime name="dateTime1" label="DateTime" disabled="true"></rlDateTime>
+<rlAbsoluteTime name="time1" label="AbsoluteTime" disabled="true"></rlAbsoluteTime>
+<rlUserRating name="userRating1" disabled="true"></rlUserRating>

--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -3,7 +3,7 @@
 	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/checkbox/checkbox.md">Checkbox</a>:</label>
 	<div><rlCheckbox [(value)]="checked" label="Checkbox with 2-way binding"></rlCheckbox></div>
 	<div><rlCheckbox value="false" [active]="false" label="Inactive"></rlCheckbox></div>
-	<div><rlCheckbox [active]="true" label="Disabled"></rlCheckbox></div>
+	<div><rlCheckbox [disabled]="true" label="Disabled"></rlCheckbox></div>
 	<div><rlCheckbox (change)="log($event)" label="Output event"></rlCheckbox></div>
 	<div>Value: {{checked}}</div>
 </div>

--- a/bootstrapper/inputs/inputsNg2Bootstrapper.ts
+++ b/bootstrapper/inputs/inputsNg2Bootstrapper.ts
@@ -1,0 +1,88 @@
+import { Component, ViewChild } from '@angular/core';
+import * as moment from 'moment';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { filter } from 'lodash';
+
+import { services } from 'typescript-angular-utilities';
+import __timezone = services.timezone;
+
+import { FormComponent } from '../../source/components/form/form';
+import { BUTTON_DIRECTIVES } from '../../source/components/buttons/index';
+import { INPUT_DIRECTIVES } from '../../source/components/inputs/index';
+
+export interface ITestItem {
+	value: number;
+}
+
+export interface ITestItem2 {
+	value: string;
+}
+
+@Component({
+	selector: 'tsinputsBootstrapper',
+	template: require('./inputsNg2.html'),
+	directives: [
+		FormComponent,
+		BUTTON_DIRECTIVES,
+		INPUT_DIRECTIVES,
+	],
+})
+export class InputsBootstrapper {
+	checked: boolean;
+	text: string;
+	date: moment.Moment;
+	selection: ITestItem;
+	rating: number;
+	time: string;
+
+	options: ITestItem[];
+	optionsAsync: Observable<ITestItem[]>;
+	typeaheadOptions: ITestItem2[];
+	selections: ITestItem2[];
+
+	constructor(timezoneService: __timezone.TimezoneService) {
+		timezoneService.setCurrentTimezone('-05:00');
+
+		this.text = 'Something is already entered';
+		this.options = [
+			{ value: 1 },
+			{ value: 2 },
+			{ value: 3 },
+		];
+		this.selection = this.options[0];
+		this.optionsAsync = this.wait(this.options);
+		this.time = '8:00AM';
+
+		this.typeaheadOptions = [
+			{ value: 'Option 1' },
+			{ value: 'Option 2' },
+			{ value: 'Option 3' },
+			{ value: 'Option 4' },
+			{ value: 'Option 5' },
+		];
+
+		this.selections = [this.typeaheadOptions[0], this.typeaheadOptions[2]]
+	}
+
+	wait(data: any): Observable<any> {
+		const subject: BehaviorSubject<ITestItem[]> = new BehaviorSubject<ITestItem[]>([]);
+		setTimeout(() => subject.next(data), 1000);
+		return subject.asObservable();
+	}
+
+	getOptions = (): Observable<any> => {
+		return Observable.of(this.typeaheadOptions);
+	}
+
+	searchOptions = (search: string): Observable<any> => {
+		return this.wait(filter(this.typeaheadOptions, option => option.value.search(search) != -1));
+	}
+
+	createOption = (text: string): any => {
+		return { value: text };
+	}
+
+	log(value: any): void {
+		console.log(value);
+	}
+}

--- a/source/behaviors/autosave/autosave.tests.ts
+++ b/source/behaviors/autosave/autosave.tests.ts
@@ -1,0 +1,141 @@
+import { Subject } from 'rxjs';
+
+import { services } from 'typescript-angular-utilities';
+import __test = services.test;
+import fakeAsync = __test.fakeAsync;
+import tick = __test.tick;
+import flushMicrotasks = __test.flushMicrotasks;
+
+import { AutosaveDirective, DEFAULT_AUTOSAVE_DEBOUNCE } from './autosave';
+
+interface IFormMock {
+	form: { statusChanges: Subject<void> };
+	validate: Sinon.SinonSpy;
+	submitAndWait: Sinon.SinonSpy;
+}
+
+interface IAutosaveActionMock {
+	trigger: Sinon.SinonSpy;
+}
+
+describe('AutosaveDirective', () => {
+	let autosave: AutosaveDirective;
+	let form: IFormMock;
+	let autosaveAction: IAutosaveActionMock;
+
+	beforeEach(() => {
+		form = {
+			form: { statusChanges: new Subject<void>() },
+			validate: sinon.spy(() => true),
+			submitAndWait: sinon.spy(),
+		};
+
+		autosaveAction = { trigger: sinon.spy() };
+
+		autosave = new AutosaveDirective(<any>form, new services.timeout.TimeoutService(), <any>autosaveAction);
+	});
+
+	describe('ngAfterViewInit', (): void => {
+		it('should start an autosave check on form status changes', (): void => {
+			const setDebounceSpy = sinon.spy();
+			autosave.setDebounce = setDebounceSpy;
+			autosave.ngAfterViewInit();
+
+			form.form.statusChanges.next(null);
+
+			sinon.assert.calledOnce(setDebounceSpy);
+		});
+	});
+
+	describe('setDebounce', () => {
+		it('should set a timer to autosave after the specified duration', fakeAsync((): void => {
+			const autosaveSpy = sinon.spy();
+			autosave.autosave = autosaveSpy;
+
+			autosave.setDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			flushMicrotasks();
+
+			sinon.assert.calledOnce(autosaveSpy);
+		}));
+
+		it('should only autosave once if called again while the timer is in progress', fakeAsync(() => {
+			const autosaveSpy = sinon.spy();
+			autosave.autosave = autosaveSpy;
+
+			autosave.setDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			flushMicrotasks();
+
+			autosave.setDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			flushMicrotasks();
+
+			sinon.assert.calledOnce(autosaveSpy);
+		}));
+
+		it('should not trigger an autosave if the form is invalid', fakeAsync(() => {
+			const autosaveSpy = sinon.spy();
+			autosave.autosave = autosaveSpy;
+			form.validate = sinon.spy(() => false);
+
+			autosave.setDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			flushMicrotasks();
+
+			sinon.assert.notCalled(autosaveSpy);
+		}));
+	});
+
+	describe('resetDebounce', () => {
+		it('should reset the timer for autosaving', fakeAsync(() => {
+			const autosaveSpy = sinon.spy();
+			autosave.autosave = autosaveSpy;
+
+			autosave.setDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			flushMicrotasks();
+
+			autosave.resetDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			flushMicrotasks();
+
+			sinon.assert.notCalled(autosaveSpy);
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			flushMicrotasks();
+
+			sinon.assert.calledOnce(autosaveSpy);
+		}));
+
+		it('should do nothing if no timer is in progress', fakeAsync(() => {
+			const autosaveSpy = sinon.spy();
+			autosave.autosave = autosaveSpy;
+
+			autosave.resetDebounce();
+
+			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			flushMicrotasks();
+
+			sinon.assert.notCalled(autosaveSpy);
+		}));
+	});
+
+	describe('autosave', () => {
+		it('should submit the form and pass the wait value to the autosave action', () => {
+			const waitValue = __test.mock.request()();
+			form.submitAndWait = sinon.spy(() => waitValue);
+
+			autosave.autosave();
+
+			sinon.assert.calledOnce(autosaveAction.trigger);
+			sinon.assert.calledWith(autosaveAction.trigger, waitValue);
+		});
+	});
+});

--- a/source/behaviors/autosave/autosave.ts
+++ b/source/behaviors/autosave/autosave.ts
@@ -6,7 +6,7 @@ import __timeout = services.timeout;
 import { FormComponent } from '../../components/form/form';
 import { AutosaveActionService } from '../../services/autosaveAction/autosaveAction.service';
 
-const DEFAULT_AUTOSAVE_DEBOUNCE: number = 3000;
+export const DEFAULT_AUTOSAVE_DEBOUNCE: number = 3000;
 
 @Directive({
 	selector: '[rlAutosave]',

--- a/source/behaviors/autosave/autosave.ts
+++ b/source/behaviors/autosave/autosave.ts
@@ -28,7 +28,7 @@ export class AutosaveDirective implements AfterViewInit {
 	}
 
 	setDebounce = (): void => {
-		if (this.form.validate()) {
+		if (!this.timer && this.form.validate()) {
 			this.timer = this.timeoutService.setTimeout(this.autosave, DEFAULT_AUTOSAVE_DEBOUNCE)
 											.catch(() => null);
 		}

--- a/source/behaviors/autosave/autosave.ts
+++ b/source/behaviors/autosave/autosave.ts
@@ -47,8 +47,8 @@ export class AutosaveDirective implements AfterViewInit {
 	}
 
 	autosave = (): void => {
-		console.log('Autosave');
-		this.autosaveAction.trigger(this.timeoutService.setTimeout(1000));
+		const waitOn = this.form.submitAndWait();
+		this.autosaveAction.trigger(waitOn);
 		this.timer = null;
 	}
 }

--- a/source/behaviors/autosave/autosave.ts
+++ b/source/behaviors/autosave/autosave.ts
@@ -1,15 +1,49 @@
-import { Directive, Self } from '@angular/core';
+import { Directive, Self, AfterViewInit, HostListener } from '@angular/core';
+
+import { services } from 'typescript-angular-utilities';
+import __timeout = services.timeout;
 
 import { FormComponent } from '../../components/form/form';
+
+const DEFAULT_AUTOSAVE_DEBOUNCE: number = 3000;
 
 @Directive({
 	selector: '[rlAutosave]',
 })
-export class AutosaveDirective {
-	form: FormComponent;
+export class AutosaveDirective implements AfterViewInit {
+	@HostListener('keyup') keyupListener = this.resetDebounce;
 
-	constructor( @Self() form: FormComponent) {
+	timer: __timeout.ITimeout;
+	form: FormComponent;
+	timeoutService: __timeout.TimeoutService;
+
+	constructor( @Self() form: FormComponent
+			, timeoutService: __timeout.TimeoutService) {
 		this.form = form;
-		form.form.statusChanges.subscribe(value => console.log(value));
+		this.timeoutService = timeoutService;
+	}
+
+	ngAfterViewInit(): void {
+		this.form.form.statusChanges.subscribe(this.setDebounce);
+	}
+
+	setDebounce = (): void => {
+		if (this.form.validate()) {
+			this.timer = this.timeoutService.setTimeout(this.autosave, DEFAULT_AUTOSAVE_DEBOUNCE)
+											.catch(() => null);
+		}
+	}
+
+	resetDebounce(): void {
+		if (this.timer) {
+			this.timer.cancel();
+			this.timer = null;
+			this.setDebounce();
+		}
+	}
+
+	autosave = (): void => {
+		console.log('Autosave');
+		this.timer = null;
 	}
 }

--- a/source/behaviors/autosave/autosave.ts
+++ b/source/behaviors/autosave/autosave.ts
@@ -1,0 +1,15 @@
+import { Directive, Self } from '@angular/core';
+
+import { FormComponent } from '../../components/form/form';
+
+@Directive({
+	selector: '[rlAutosave]',
+})
+export class AutosaveDirective {
+	form: FormComponent;
+
+	constructor( @Self() form: FormComponent) {
+		this.form = form;
+		form.form.statusChanges.subscribe(value => console.log(value));
+	}
+}

--- a/source/behaviors/autosave/autosave.ts
+++ b/source/behaviors/autosave/autosave.ts
@@ -4,6 +4,7 @@ import { services } from 'typescript-angular-utilities';
 import __timeout = services.timeout;
 
 import { FormComponent } from '../../components/form/form';
+import { AutosaveActionService } from '../../services/autosaveAction/autosaveAction.service';
 
 const DEFAULT_AUTOSAVE_DEBOUNCE: number = 3000;
 
@@ -16,11 +17,14 @@ export class AutosaveDirective implements AfterViewInit {
 	timer: __timeout.ITimeout;
 	form: FormComponent;
 	timeoutService: __timeout.TimeoutService;
+	autosaveAction: AutosaveActionService;
 
 	constructor( @Self() form: FormComponent
-			, timeoutService: __timeout.TimeoutService) {
+			, timeoutService: __timeout.TimeoutService
+			, autosaveAction: AutosaveActionService) {
 		this.form = form;
 		this.timeoutService = timeoutService;
+		this.autosaveAction = autosaveAction;
 	}
 
 	ngAfterViewInit(): void {
@@ -44,6 +48,7 @@ export class AutosaveDirective implements AfterViewInit {
 
 	autosave = (): void => {
 		console.log('Autosave');
+		this.autosaveAction.trigger(this.timeoutService.setTimeout(1000));
 		this.timer = null;
 	}
 }

--- a/source/componentsDowngrade.ts
+++ b/source/componentsDowngrade.ts
@@ -31,6 +31,7 @@ import { DatePipe } from './pipes/date/date.pipe';
 import { LocalizeStringDatesPipe } from './pipes/localizeStringDates/localizeStringDates.pipe';
 
 import { AsyncHelper } from './services/async/async.service';
+import { AutosaveActionService } from './services/autosaveAction/autosaveAction.service';
 import { DocumentService } from './services/documentWrapper/documentWrapper.service';
 import { FormService } from './services/form/form.service';
 import { JQUERY_PROVIDER } from './services/jquery/jquery.provider';
@@ -44,6 +45,7 @@ export { visibleBreakpointServiceName };
 
 export const moduleName: string = 'rl.components.downgrade';
 
+export const autosaveActionServiceName: string = 'autosaveAction';
 export const cardContainerBuilderServiceName: string = 'rlCardContainerBuilder';
 export const dataPagerFactoryName: string = 'rlDataPagerFactory';
 export const documentServiceName: string = 'documentWrapper';
@@ -85,6 +87,7 @@ export function downgradeComponentsToAngular1(upgradeAdapter: UpgradeAdapter) {
 	});
 
 	upgradeAdapter.addProvider(AsyncHelper);
+	upgradeAdapter.addProvider(AutosaveActionService);
 	upgradeAdapter.addProvider(DefaultTheme);
 	upgradeAdapter.addProvider(defaultThemeNg1);
 	upgradeAdapter.addProvider(DialogRootService);
@@ -119,6 +122,7 @@ export function downgradeComponentsToAngular1(upgradeAdapter: UpgradeAdapter) {
 	componentsDowngradeModule.directive('rlTextboxNg', <any>upgradeAdapter.downgradeNg2Component(TextboxComponent));
 	componentsDowngradeModule.directive('rlStringWithWatermarkNg', <any>upgradeAdapter.downgradeNg2Component(StringWithWatermarkComponent));
 
+	componentsDowngradeModule.factory(autosaveActionServiceName, upgradeAdapter.downgradeNg2Provider(AutosaveActionService));
 	componentsDowngradeModule.factory(cardContainerBuilderServiceName, upgradeAdapter.downgradeNg2Provider(CardContainerBuilder));
 	componentsDowngradeModule.factory(dataPagerFactoryName, upgradeAdapter.downgradeNg2Provider(DataPager));
 	componentsDowngradeModule.factory(columnSearchFilterName, upgradeAdapter.downgradeNg2Provider(ColumnSearchFilter));

--- a/source/services/autosave/autosave.service.ts
+++ b/source/services/autosave/autosave.service.ts
@@ -4,11 +4,8 @@ import * as _ from 'lodash';
 import { services, downgrade } from 'typescript-angular-utilities';
 import __notification = services.notification;
 
-import {
-	moduleName as autosaveActionModuleName,
-	serviceName as autosaveActionServiceName,
-	IAutosaveActionService,
-} from '../autosaveAction/autosaveAction.service';
+import { IAutosaveActionService } from '../autosaveAction/autosaveAction.service';
+import { autosaveActionServiceName, moduleName as componentsDowngradeModule } from '../../componentsDowngrade';
 import * as triggers from './triggers/triggers.service';
 import { IFormService, serviceName as formServiceName, moduleName as formModule } from '../form/form.service.ng1';
 import { IFormValidator } from '../../types/formValidators';
@@ -129,5 +126,5 @@ function autosaveServiceFactory(notification: __notification.INotificationServic
 	};
 }
 
-angular.module(moduleName, [downgrade.moduleName, autosaveActionModuleName, triggers.moduleName, formModule])
+angular.module(moduleName, [downgrade.moduleName, componentsDowngradeModule, triggers.moduleName, formModule])
 	.factory(factoryName, autosaveServiceFactory);

--- a/source/services/autosaveAction/autosaveAction.service.ts
+++ b/source/services/autosaveAction/autosaveAction.service.ts
@@ -6,6 +6,8 @@ import __digest = services.digestService;
 
 import { AsyncHelper, IWaitValue } from '../async/async.service';
 
+export const COMPLETE_MESSAGE_DURATION: number = 1000;
+
 export interface IAutosaveActionService {
 	trigger(promise: Promise<any>): void;
 	saving: boolean;
@@ -26,8 +28,6 @@ export class AutosaveActionService implements IAutosaveActionService {
 		this.asyncService = asyncService;
 		this.digestService = digestService;
 	}
-
-	private completeMessageDuration: number = 1000;
 
 	private _saving: boolean;
 	private _complete: boolean;
@@ -68,6 +68,6 @@ export class AutosaveActionService implements IAutosaveActionService {
 			this._complete = false;
 			// remove this once ng1 goes away
 			this.digestService.runDigestCycle();
-		}, this.completeMessageDuration);
+		}, COMPLETE_MESSAGE_DURATION);
 	}
 }

--- a/source/services/services.module.ts
+++ b/source/services/services.module.ts
@@ -39,7 +39,6 @@ export var moduleName: string = 'rl.ui.services';
 
 angular.module(moduleName, [
 	autosave.moduleName,
-	autosaveAction.moduleName,
 	breakpointsNg1.moduleName,
 	componentValidator.moduleName,
 	contentProvider.moduleName,


### PR DESCRIPTION
Use some more WIP-blocked time to knock out autosave functionality. Autosave is now simply a directive that attaches to the form to provide autosave behavior. On form status changes, check the validation state and if valid, initiate an autosave cycle. The cycle begins with a debounce timer that will trigger the save itself. Keyup events anywhere on the form will reset the timer. Also, if a keyup event causes the form to become invalid, the save is canceled until validation is resolved. Since this is an autosave, no validation error is notified, as that would lead to spamming the page with toasts.

TODO: Implement ability to save the form in an invalid state with a flag set. This is used in MUSIC for 'business rule' validation, such as arrived time being after received time. We still want to save the fields, the user just can't close the SE until the error is resolved.
