### PR TITLE
Remove the “100th” option from the available page sizes

### DIFF
--- a/source/components/cardContainer/paging/pageSize/pageSize.ng1.ts
+++ b/source/components/cardContainer/paging/pageSize/pageSize.ng1.ts
@@ -9,7 +9,7 @@ export const moduleName: string = 'rl.ui.components.cardContainer.pageSize';
 export const componentName: string = 'rlPageSize';
 export const controllerName: string = 'PageSizeController';
 
-export const availablePageSizes: number[] = [10, 25, 50, 100];
+export const availablePageSizes: number[] = [10, 25, 50];
 export const defaultPageSize: number = 10;
 
 export class PageSizeController {

--- a/source/components/cardContainer/paging/pageSize/pageSize.ts
+++ b/source/components/cardContainer/paging/pageSize/pageSize.ts
@@ -4,7 +4,7 @@ import { IDataPager } from '../dataPager/dataPager.service';
 import { CardContainerComponent } from '../../cardContainer';
 import { SelectComponent } from '../../../inputs/index';
 
-export const availablePageSizes: number[] = [10, 25, 50, 100];
+export const availablePageSizes: number[] = [10, 25, 50];
 
 @Component({
 	selector: 'rlPageSize',


### PR DESCRIPTION
100 options-a-page proved to be too many, causing crashes in some web browsers. _cough_ like firefox _cough_
