### PR TITLE
Limit page size options again

### DIFF
--- a/source/components/cardContainer/paging/pageSize/pageSize.ng1.ts
+++ b/source/components/cardContainer/paging/pageSize/pageSize.ng1.ts
@@ -9,7 +9,7 @@ export const moduleName: string = 'rl.ui.components.cardContainer.pageSize';
 export const componentName: string = 'rlPageSize';
 export const controllerName: string = 'PageSizeController';
 
-export const availablePageSizes: number[] = [10, 25, 50];
+export const availablePageSizes: number[] = [10, 15, 20, 25];
 export const defaultPageSize: number = 10;
 
 export class PageSizeController {

--- a/source/components/cardContainer/paging/pageSize/pageSize.ts
+++ b/source/components/cardContainer/paging/pageSize/pageSize.ts
@@ -4,7 +4,7 @@ import { IDataPager } from '../dataPager/dataPager.service';
 import { CardContainerComponent } from '../../cardContainer';
 import { SelectComponent } from '../../../inputs/index';
 
-export const availablePageSizes: number[] = [10, 25, 50];
+export const availablePageSizes: number[] = [10, 15, 20, 25];
 
 @Component({
 	selector: 'rlPageSize',


### PR DESCRIPTION
Firefox was still crashing with a max item count of 50. 25, however, does not seem to break firefox. So, we are reducing the numbers of options yet again.
