### PR TITLE
Inputs fix

### DIFF
--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -35,6 +35,7 @@
 		<template let-option>#{{option.value}}</template>
 	</rlSelect>
 	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
+	<rlSelect [value]="selection" (change)="log($event)" label="Output event" [options]="options" transform="value"></rlSelect>
 </div>
 <div>
 	<label><a href="https://github.com/SamGraber/TypeScript-Angular-Components/tree/master/source/components/inputs/typeahead/typeahead.md">Typeahead</a>:</label>

--- a/source/components/inputs/input.tests.ts
+++ b/source/components/inputs/input.tests.ts
@@ -22,7 +22,7 @@ interface IControlMock {
 	markAsDirty?: Sinon.SinonSpy;
 }
 
-describe('base input', (): void => {
+describe('InputComponent', (): void => {
 	let input: InputComponent<number>;
 	let rlForm: IFormMock;
 	let guid: IGuidMock;

--- a/source/components/inputs/input.tests.ts
+++ b/source/components/inputs/input.tests.ts
@@ -51,7 +51,7 @@ describe('InputComponent', (): void => {
 	});
 
 	it('should add the control to the form using the name if a form is present', (): void => {
-		const control: any = {};
+		const control: any = { valueChanges: new Subject<number>() };
 		input.control = control;
 		input.name = 'name';
 
@@ -68,7 +68,7 @@ describe('InputComponent', (): void => {
 		const changeSpy: Sinon.SinonSpy = sinon.spy();
 		input.change.emit = changeSpy;
 
-		input.initControl();
+		input.ngAfterViewInit();
 
 		control.valueChanges.next(3);
 

--- a/source/components/inputs/input.tests.ts
+++ b/source/components/inputs/input.tests.ts
@@ -96,8 +96,6 @@ describe('InputComponent', (): void => {
 		sinon.assert.calledOnce(control.markAsDirty);
 		sinon.assert.calledOnce(control.updateValue);
 		sinon.assert.calledWith(control.updateValue, 5);
-		sinon.assert.calledOnce(changeSpy);
-		sinon.assert.calledWith(changeSpy, 5);
 	});
 
 	it('should ignore updates if disabled', (): void => {

--- a/source/components/inputs/input.ts
+++ b/source/components/inputs/input.ts
@@ -42,17 +42,17 @@ export class InputComponent<T> implements AfterViewInit, OnInit {
 		if (this.rlForm) {
 			this.rlForm.form.addControl(this.name, this.control);
 		}
+
+		this.control.valueChanges.subscribe(value => {
+			this.value = value;
+			this.change.emit(value);
+		});
 	}
 
 	initControl(): void {
 		if (!this.control) {
 			this.control = new FormControl('');
 		}
-
-		this.control.valueChanges.subscribe(value => {
-			this.value = value;
-			this.change.emit(value);
-		});
 	}
 
 	setValue(value: T): void {

--- a/source/components/inputs/input.ts
+++ b/source/components/inputs/input.ts
@@ -60,7 +60,6 @@ export class InputComponent<T> implements AfterViewInit, OnInit {
 			this.value = value;
 			this.control.markAsDirty();
 			this.control.updateValue(this.value);
-			this.change.emit(this.value);
 		}
 	}
 }

--- a/source/components/inputs/select/select.tests.ts
+++ b/source/components/inputs/select/select.tests.ts
@@ -88,6 +88,19 @@ describe('SelectComponent', () => {
 		sinon.assert.calledWith(setValue, options[1]);
 	});
 
+	it('should close the options without setting the value if the current value is reselected', (): void => {
+		const closeSpy = sinon.spy();
+		dropdown.list = <any>{
+			close: closeSpy,
+		};
+		dropdown.value = options[1];
+
+		dropdown.select(options[1]);
+
+		sinon.assert.calledOnce(closeSpy);
+		sinon.assert.notCalled(setValue);
+	});
+
 	it('should transform the item to a display name', (): void => {
 		const option: ITestOption = { value: 3 };
 		const transform: string = 'value';

--- a/source/components/inputs/select/select.ts
+++ b/source/components/inputs/select/select.ts
@@ -58,7 +58,9 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 	}
 
 	select(value: T): void {
-		this.setValue(value);
+		if (value != this.value) {
+			this.setValue(value);
+		}
 		this.list.close();
 	}
 

--- a/source/components/inputs/validationInput.tests.ts
+++ b/source/components/inputs/validationInput.tests.ts
@@ -18,7 +18,7 @@ interface IComponentValidatorMock {
 	validate: Sinon.SinonSpy;
 }
 
-describe('base validating input', (): void => {
+describe('ValidatedInputComponent', (): void => {
 	let input: ValidatedInputComponent<number>;
 	let componentValidator: IComponentValidatorMock;
 

--- a/source/components/inputs/validationInput.tests.ts
+++ b/source/components/inputs/validationInput.tests.ts
@@ -10,6 +10,7 @@ import { ValidatedInputComponent, IInputChanges } from './validationInput';
 interface IControlMock {
 	updateValueAndValidity?: Sinon.SinonSpy;
 	updateValue?: Sinon.SinonSpy;
+	valueChanges?: { subscribe: Sinon.SinonSpy };
 }
 
 interface IComponentValidatorMock {
@@ -66,7 +67,10 @@ describe('ValidatedInputComponent', (): void => {
 	});
 
 	it('should set the control on the component validator and update the validity of the control', (): void => {
-		const control: IControlMock = { updateValueAndValidity: sinon.spy() };
+		const control: IControlMock = {
+			updateValueAndValidity: sinon.spy(),
+			valueChanges: { subscribe: sinon.spy() },
+		};
 		input.control = <any>control;
 		input.value = 4;
 
@@ -80,7 +84,10 @@ describe('ValidatedInputComponent', (): void => {
 
 	// updateValueAndValidity doesn't handle 'null' properly
 	it('should default the value to undefined if null', (): void => {
-		const control: IControlMock = { updateValueAndValidity: sinon.spy() };
+		const control: IControlMock = {
+			updateValueAndValidity: sinon.spy(),
+			valueChanges: { subscribe: sinon.spy() },
+		};
 		input.control = <any>control;
 		input.value = null;
 


### PR DESCRIPTION
This change was driven by the need to accommodate a case Andy ran into when migrating the status selector to angular 2. We were having issues where inputs were a little too trigger happy with firing change events. First, if you set a value model, the change event would fire twice with the initial selection. Then also, changing the value caused two change events to be fired. The second issue was causing trouble in the service times editor, and we did a temporary workaround for it there.

Also, tweaked select inputs to not fire a change event when re-selecting the currently selected value.
