### PR TITLE
Only emit a change as part of the setValue

### DIFF
--- a/source/components/inputs/input.tests.ts
+++ b/source/components/inputs/input.tests.ts
@@ -61,20 +61,15 @@ describe('InputComponent', (): void => {
 		sinon.assert.calledWith(rlForm.form.addControl, 'name', control);
 	});
 
-	it('should subscribe to changes on the form, update the value, and emit the changes', (): void => {
+	it('should subscribe to changes on the form control and update the value', (): void => {
 		const control: IControlMock = { valueChanges: new Subject<number>() };
 		input.control = <any>control;
-
-		const changeSpy: Sinon.SinonSpy = sinon.spy();
-		input.change.emit = changeSpy;
 
 		input.ngAfterViewInit();
 
 		control.valueChanges.next(3);
 
 		expect(input.value).to.equal(3);
-		sinon.assert.calledOnce(changeSpy);
-		sinon.assert.calledWith(changeSpy, 3);
 	});
 
 	it('should initialize the control if none is present', (): void => {
@@ -96,6 +91,8 @@ describe('InputComponent', (): void => {
 		sinon.assert.calledOnce(control.markAsDirty);
 		sinon.assert.calledOnce(control.updateValue);
 		sinon.assert.calledWith(control.updateValue, 5);
+		sinon.assert.calledOnce(changeSpy);
+		sinon.assert.calledWith(changeSpy, 5);
 	});
 
 	it('should ignore updates if disabled', (): void => {

--- a/source/components/inputs/input.ts
+++ b/source/components/inputs/input.ts
@@ -45,7 +45,6 @@ export class InputComponent<T> implements AfterViewInit, OnInit {
 
 		this.control.valueChanges.subscribe(value => {
 			this.value = value;
-			this.change.emit(value);
 		});
 	}
 
@@ -60,6 +59,7 @@ export class InputComponent<T> implements AfterViewInit, OnInit {
 			this.value = value;
 			this.control.markAsDirty();
 			this.control.updateValue(this.value);
+			this.change.emit(value);
 		}
 	}
 }


### PR DESCRIPTION
We should really only emit changes that were triggered from within the input. Also, fixes an issue we were having when an output event triggers a change to the input. This change gets picked up here and fires another output.

Temporarily violating the WIP to get this change made for Andy. Should have no QA impact anyway.
