### PR TITLE
Synchronized requests refactor

### DIFF
--- a/bootstrapper/cards/cardsNg2Bootstrapper.ts
+++ b/bootstrapper/cards/cardsNg2Bootstrapper.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { mapValues, map, range } from 'lodash';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 import { services } from 'typescript-angular-utilities';
 import __date = services.date;
@@ -59,7 +60,7 @@ export class CardsBootstrapper {
 		this.options = [1, 2, 3, 4, 5];
 
 		this.builder = cardContainerBuilder;
-		this.builder.dataSource.buildSimpleDataSource(items);
+		this.builder.dataSource.buildDataServiceDataSource<ICardItem>(() => this.wait(items));
 		this.builder.usePaging();
 		this.builder.addColumn({
 			name: 'name',
@@ -139,6 +140,12 @@ export class CardsBootstrapper {
 		this.modeFilterGroup.subscribe(value => console.log(value));
 		this.rangeFilterGroup.subscribe(value => console.log(value));
 		this.selectFilter.subscribe(value => console.log(value));
+	}
+
+	wait(data: any): Observable<any> {
+		const subject: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
+		setTimeout(() => subject.next(data), 1000);
+		return subject.asObservable();
 	}
 
 	submitAsync: { (data: any): Promise<void> } = (data: any) => {

--- a/bootstrapper/cards/cardsNg2Bootstrapper.ts
+++ b/bootstrapper/cards/cardsNg2Bootstrapper.ts
@@ -60,7 +60,7 @@ export class CardsBootstrapper {
 		this.options = [1, 2, 3, 4, 5];
 
 		this.builder = cardContainerBuilder;
-		this.builder.dataSource.buildDataServiceDataSource<ICardItem>(() => this.wait(items));
+		this.builder.dataSource.buildDataServiceDataSource<ICardItem>(() => Observable.of(items).delay(1000));
 		this.builder.usePaging();
 		this.builder.addColumn({
 			name: 'name',
@@ -140,12 +140,6 @@ export class CardsBootstrapper {
 		this.modeFilterGroup.subscribe(value => console.log(value));
 		this.rangeFilterGroup.subscribe(value => console.log(value));
 		this.selectFilter.subscribe(value => console.log(value));
-	}
-
-	wait(data: any): Observable<any> {
-		const subject: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
-		setTimeout(() => subject.next(data), 1000);
-		return subject.asObservable();
 	}
 
 	submitAsync: { (data: any): Promise<void> } = (data: any) => {

--- a/bootstrapper/inputs/inputsNg2Bootstrapper.ts
+++ b/bootstrapper/inputs/inputsNg2Bootstrapper.ts
@@ -50,7 +50,7 @@ export class InputsBootstrapper {
 			{ value: 3 },
 		];
 		this.selection = this.options[0];
-		this.optionsAsync = this.wait(this.options);
+		this.optionsAsync = Observable.of(this.options).delay(1000);
 		this.time = '8:00AM';
 
 		this.typeaheadOptions = [
@@ -64,18 +64,12 @@ export class InputsBootstrapper {
 		this.selections = [this.typeaheadOptions[0], this.typeaheadOptions[2]]
 	}
 
-	wait(data: any): Observable<any> {
-		const subject: BehaviorSubject<ITestItem[]> = new BehaviorSubject<ITestItem[]>([]);
-		setTimeout(() => subject.next(data), 1000);
-		return subject.asObservable();
-	}
-
 	getOptions = (): Observable<any> => {
 		return Observable.of(this.typeaheadOptions);
 	}
 
 	searchOptions = (search: string): Observable<any> => {
-		return this.wait(filter(this.typeaheadOptions, option => option.value.search(search) != -1));
+		return Observable.of(filter(this.typeaheadOptions, option => option.value.search(search) != -1)).delay(1000);
 	}
 
 	createOption = (text: string): any => {

--- a/bootstrapper/misc/miscNg2Context.ts
+++ b/bootstrapper/misc/miscNg2Context.ts
@@ -16,9 +16,7 @@ export class MiscNgContextBootstrapper {
 	value: number = 0;
 
 	wait(): Observable<void> {
-		const subject: Subject<void> = new Subject<void>();
-		setTimeout(() => subject.next(null), 1000);
-		return subject;
+		return Observable.of(null).delay(1000);
 	}
 
 	toggle(): void {

--- a/source/components/cardContainer/builder/dataSourceBuilder.service.ts
+++ b/source/components/cardContainer/builder/dataSourceBuilder.service.ts
@@ -4,7 +4,6 @@ import { isUndefined } from 'lodash';
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
 import __array = services.array;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import * as dataSources from '../dataSources/index';
 import { ISorter, Sorter } from '../sorts/index';
@@ -27,18 +26,15 @@ export class DataSourceBuilder implements IDataSourceBuilder {
 	private parent: CardContainerBuilder;
 	private object: __object.ObjectUtility;
 	private array: __array.IArrayUtility;
-	private synchronizedRequestsFactory: __synchronizedRequests.ISynchronizedRequestsFactory;
 	private sorter: Sorter;
 
 	constructor(injector: Injector
 			, object: __object.ObjectUtility
 			, array: __array.ArrayUtility
-			, synchronizedRequestsFactory: __synchronizedRequests.SynchronizedRequestsFactory
 			, sorter: Sorter) {
 		this.injector = injector;
 		this.object = object;
 		this.array = array;
-		this.synchronizedRequestsFactory = synchronizedRequestsFactory;
 		this.sorter = sorter;
 	}
 
@@ -56,7 +52,7 @@ export class DataSourceBuilder implements IDataSourceBuilder {
 
 	buildDataServiceDataSource<TDataType>(getDataSet: dataSources.IDataServiceFunction<TDataType>): dataSources.IAsyncDataSource<TDataType> {
 		let processor: dataSources.IDataSourceProcessor = new dataSources.DataSourceProcessor(this.object, this.sorter);
-		this.parent._dataSource = new dataSources.DataServiceDataSource(getDataSet, processor, this.array, this.synchronizedRequestsFactory);
+		this.parent._dataSource = new dataSources.DataServiceDataSource(getDataSet, processor, this.array);
 		return <any>this.parent._dataSource;
 	}
 
@@ -68,19 +64,19 @@ export class DataSourceBuilder implements IDataSourceBuilder {
 		}
 
 		let processor: dataSources.IDataSourceProcessor = new dataSources.DataSourceProcessor(this.object, this.sorter);
-		this.parent._dataSource = new dataSources.ClientServerDataSource(getDataSet, this.parent._searchFilter, getFilterModel, validateModel, processor, this.array, this.object, this.synchronizedRequestsFactory);
+		this.parent._dataSource = new dataSources.ClientServerDataSource(getDataSet, this.parent._searchFilter, getFilterModel, validateModel, processor, this.array, this.object);
 		return <any>this.parent._dataSource;
 	}
 
 	buildServerSideDataSource<TDataType>(getDataSet: dataSources.IServerSearchFunction<TDataType>): dataSources.IAsyncDataSource<TDataType> {
 		let processor: dataSources.IDataSourceProcessor = new dataSources.DataSourceProcessor(this.object, this.sorter);
-		this.parent._dataSource = new dataSources.ServerSideDataSource(getDataSet, processor, this.array, this.object, this.synchronizedRequestsFactory);
+		this.parent._dataSource = new dataSources.ServerSideDataSource(getDataSet, processor, this.array, this.object);
 		return <any>this.parent._dataSource;
 	}
 
 	buildSmartDataSource<TDataType>(getDataSet: dataSources.IServerSearchFunction<TDataType>): dataSources.IAsyncDataSource<TDataType> {
 		let processor: dataSources.IDataSourceProcessor = new dataSources.DataSourceProcessor(this.object, this.sorter);
-		this.parent._dataSource = new dataSources.SmartDataSource(getDataSet, processor, this.array, this.object, this.synchronizedRequestsFactory);
+		this.parent._dataSource = new dataSources.SmartDataSource(getDataSet, processor, this.array, this.object);
 		return <any>this.parent._dataSource;
 	}
 

--- a/source/components/cardContainer/card/card.tests.ts
+++ b/source/components/cardContainer/card/card.tests.ts
@@ -1,7 +1,6 @@
 import { filter } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
-import __boolean = services.boolean;
 import __notification = services.notification;
 
 import { FormService } from '../../../services/form/form.service';
@@ -27,7 +26,7 @@ describe('CardComponent', () => {
 			},
 		};
 
-		card = new CardComponent(new __notification.NotificationService(<any>{}, <any>{}), null, new FormService(), null, new __boolean.BooleanUtility(), <any>cardContainer);
+		card = new CardComponent(new __notification.NotificationService(<any>{}, <any>{}), null, new FormService(), null, <any>cardContainer);
 	});
 
 	it('should pass the item to the save handler', (): void => {

--- a/source/components/cardContainer/card/card.ts
+++ b/source/components/cardContainer/card/card.ts
@@ -3,7 +3,6 @@ import { Subject } from 'rxjs';
 import { isFunction, assign } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
-import __boolean = services.boolean;
 import __notification = services.notification;
 
 import { IDataSource } from '../dataSources/dataSource';
@@ -46,16 +45,13 @@ export class CardComponent<T> extends FormComponent {
 	refresh: Subject<void> = new Subject<void>();
 
 	cardContainer: CardContainerComponent<T>;
-	boolean: __boolean.IBooleanUtility;
 
 	constructor(notification: __notification.NotificationService
 			, asyncHelper: AsyncHelper
 			, formService: FormService
 			, @Optional() @SkipSelf() parentForm: FormComponent
-			, boolean: __boolean.BooleanUtility
 			, @Inject(forwardRef(() => CardContainerComponent)) cardContainer: CardContainerComponent<T>) {
 		super(notification, asyncHelper, formService, parentForm);
-		this.boolean = boolean;
 		this.cardContainer = cardContainer;
 		this.refresh.subscribe(() => this.cardContainer.dataSource.refresh());
 	}
@@ -83,7 +79,7 @@ export class CardComponent<T> extends FormComponent {
 			return true;
 		}
 
-		const canClose: boolean = this.boolean.toBool(this.submit());
+		const canClose: boolean = !!this.submit();
 
 		if (canClose) {
 			this.showContent = false;

--- a/source/components/cardContainer/card/selectableCard.tests.ts
+++ b/source/components/cardContainer/card/selectableCard.tests.ts
@@ -21,7 +21,7 @@ describe('SelectableCardComponent', () => {
 			registerCard: sinon.spy(),
 		};
 
-		card = new SelectableCardComponent(new __notification.NotificationService(<any>{}, <any>{}), null, new FormService(), null, new __boolean.BooleanUtility(), <any>cardContainer);
+		card = new SelectableCardComponent(new __notification.NotificationService(<any>{}, <any>{}), null, new FormService(), null, <any>cardContainer);
 		card.item = { viewData: {} };
 	});
 

--- a/source/components/cardContainer/card/selectableCard.ts
+++ b/source/components/cardContainer/card/selectableCard.ts
@@ -2,7 +2,6 @@ import { Component, Inject, Provider, forwardRef, Optional, SkipSelf } from '@an
 import { isUndefined } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
-import __boolean = services.boolean;
 import __notification = services.notification;
 
 import { CheckboxComponent } from '../../inputs/index';
@@ -37,9 +36,8 @@ export class SelectableCardComponent<T extends ISelectableItem> extends CardComp
 			, asyncHelper: AsyncHelper
 			, formService: FormService
 			, @Optional() @SkipSelf() parentForm: FormComponent
-			, boolean: __boolean.BooleanUtility
 			, @Inject(forwardRef(() => CardContainerComponent)) cardContainer: CardContainerComponent<T>) {
-		super(notification, asyncHelper, formService, parentForm, boolean, cardContainer);
+		super(notification, asyncHelper, formService, parentForm, cardContainer);
 	}
 
 	setSelected(value: boolean): void {

--- a/source/components/cardContainer/dataSources/asyncTypes.ts
+++ b/source/components/cardContainer/dataSources/asyncTypes.ts
@@ -1,5 +1,7 @@
+import { Observable } from 'rxjs';
+
 export interface IServerSearchFunction<TDataType> {
-	(searchParams: IServerSearchParams): angular.IPromise<IDataResult<TDataType>>;
+	(searchParams: IServerSearchParams): Promise<IDataResult<TDataType>> | Observable<IDataResult<TDataType>>;
 }
 
 export interface IServerSearchParams {

--- a/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.tests.ts
@@ -6,7 +6,6 @@ import fakeAsync = test.fakeAsync;
 import __genericSearchFilter = services.genericSearchFilter;
 import __object = services.object;
 import __array = services.array;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { ClientServerDataSource } from './clientServerDataSource.service';
 
@@ -57,16 +56,15 @@ describe('ClientServerDataSource', () => {
 	});
 
 	describe('server search', (): void => {
-		beforeEach(inject([__array.ArrayUtility, __object.ObjectUtility, __synchronizedRequests.SynchronizedRequestsFactory]
-			, (arrayUtility, objectUtility, synchronizedRequestsFactory): void => {
+		beforeEach(inject([__array.ArrayUtility, __object.ObjectUtility]
+			, (arrayUtility, objectUtility): void => {
 			source = new ClientServerDataSource<number>(<any>dataService.get
 				, searchFilter
 				, null
 				, null
 				, dataSourceProcessor
 				, arrayUtility
-				, objectUtility
-				, synchronizedRequestsFactory);
+				, objectUtility);
 			source.reloaded.subscribe(reloadedSpy);
 			source.changed.subscribe(changedSpy);
 		}));
@@ -130,8 +128,8 @@ describe('ClientServerDataSource', () => {
 		let filterModel: ITestFilterModel;
 		let validateSpy: Sinon.SinonSpy;
 
-		beforeEach(inject([__array.ArrayUtility, __object.ObjectUtility, __synchronizedRequests.SynchronizedRequestsFactory]
-			, (arrayUtility, objectUtility, synchronizedRequestsFactory): void => {
+		beforeEach(inject([__array.ArrayUtility, __object.ObjectUtility]
+			, (arrayUtility, objectUtility): void => {
 			validateSpy = sinon.spy((model: ITestFilterModel): boolean => {
 				return model.prop != null;
 			});
@@ -144,8 +142,7 @@ describe('ClientServerDataSource', () => {
 				, validateSpy
 				, dataSourceProcessor
 				, arrayUtility
-				, objectUtility
-				, synchronizedRequestsFactory);
+				, objectUtility);
 			source.reloaded.subscribe(reloadedSpy);
 			source.changed.subscribe(changedSpy);
 		}));

--- a/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.ts
+++ b/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { Observable } from 'rxjs';
 
 import { services } from 'typescript-angular-utilities';
 import __array = services.array;
@@ -14,7 +15,7 @@ export interface IClientServerDataSource<TDataType> extends IAsyncDataSource<TDa
 }
 
 export interface IDataServiceSearchFunction<TDataType> {
-	(search: string | any): Promise<TDataType[]>;
+	(search: string | any): Promise<TDataType[]> | Observable<TDataType[]>;
 }
 
 export interface IGetFilterModel<TFilterModelType> {

--- a/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.ts
+++ b/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.ts
@@ -4,7 +4,6 @@ import { services } from 'typescript-angular-utilities';
 import __array = services.array;
 import __object = services.object;
 import __genericSearchFilter = services.genericSearchFilter;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { IAsyncDataSource, AsyncDataSource, IDataSetFunction } from '../asyncDataSource.service';
 import { IDataSourceProcessor } from '../dataSourceProcessor.service';
@@ -37,9 +36,8 @@ export class ClientServerDataSource<TDataType> extends AsyncDataSource<TDataType
 			, public validateModel: IValidateFilterModel<any>
 			, dataSourceProcessor: IDataSourceProcessor
 			, array: __array.IArrayUtility
-			, private object: __object.IObjectUtility
-			, synchronizedRequestsFactory: __synchronizedRequests.ISynchronizedRequestsFactory) {
-		super(getDataSet, dataSourceProcessor, array, synchronizedRequestsFactory);
+			, private object: __object.IObjectUtility) {
+		super(getDataSet, dataSourceProcessor, array);
 
 		this.getFilterModel = this.getFilterModel || function(): void { return null; };
 		this.validateModel = this.validateModel || function(): boolean { return true; };

--- a/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.tests.ts
@@ -5,7 +5,6 @@ import test = services.test;
 import fakeAsync = test.fakeAsync;
 import __object = services.object;
 import __array = services.array;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { DataServiceDataSource, IAsyncDataSource } from './dataServiceDataSource.service';
 
@@ -23,7 +22,6 @@ describe('DataServiceDataSource', () => {
 	let dataSourceProcessor: DataSourceProcessor;
 	let dataService: IDataServiceMock;
 	let arrayUtility: __array.ArrayUtility;
-	let synchronizedRequestsFactory: __synchronizedRequests.SynchronizedRequestsFactory;
 
 	beforeEach(() => {
 		addProviders([
@@ -32,13 +30,12 @@ describe('DataServiceDataSource', () => {
 			MergeSort,
 			services.UTILITY_PROVIDERS,
 		]);
-		inject([DataSourceProcessor, __array.ArrayUtility, __synchronizedRequests.SynchronizedRequestsFactory]
-			, (_dataSourceProcessor, _array, _synchronizedRequestsFactory) => {
+		inject([DataSourceProcessor, __array.ArrayUtility]
+			, (_dataSourceProcessor, _array) => {
 
 			dataSourceProcessor = _dataSourceProcessor;
 			sinon.spy(dataSourceProcessor, 'processAndCount');
 			arrayUtility = _array;
-			synchronizedRequestsFactory = _synchronizedRequestsFactory;
 		})();
 
 		dataService = <any> {};
@@ -48,7 +45,7 @@ describe('DataServiceDataSource', () => {
 		it('should call data processor to process the data when refreshing', fakeAsync((): void => {
 			dataService.get = test.mock.promise([1, 2, 3]);
 
-			new DataServiceDataSource(dataService.get, dataSourceProcessor, arrayUtility, synchronizedRequestsFactory);
+			new DataServiceDataSource(dataService.get, dataSourceProcessor, arrayUtility);
 			test.mock.flushAll(dataService)
 
 			sinon.assert.calledOnce(<Sinon.SinonSpy>dataSourceProcessor.processAndCount);
@@ -57,7 +54,7 @@ describe('DataServiceDataSource', () => {
 		it('should make an initial request to the server for data', fakeAsync((): void => {
 			dataService.get = test.mock.promise([1, 2]);
 
-			let source: IAsyncDataSource<number> = new DataServiceDataSource<number>(dataService.get, dataSourceProcessor, arrayUtility, synchronizedRequestsFactory);
+			let source: IAsyncDataSource<number> = new DataServiceDataSource<number>(dataService.get, dataSourceProcessor, arrayUtility);
 
 			let reloadedSpy: Sinon.SinonSpy = sinon.spy();
 			source.reloaded.subscribe(reloadedSpy);

--- a/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.ts
+++ b/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { Observable } from 'rxjs';
 
 import { services } from 'typescript-angular-utilities';
 import __array = services.array;
@@ -9,7 +10,7 @@ import { IDataSourceProcessor } from '../dataSourceProcessor.service';
 export { IAsyncDataSource };
 
 export interface IDataServiceFunction<TDataType> {
-	(): Promise<TDataType[]>;
+	(): Promise<TDataType[]> | Observable<TDataType[]>;
 }
 
 export class DataServiceDataSource<TDataType> extends AsyncDataSource<TDataType> implements IAsyncDataSource<TDataType> {

--- a/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.ts
+++ b/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __array = services.array;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { IAsyncDataSource, AsyncDataSource, IDataSetFunction } from '../asyncDataSource.service';
 import { IDataSourceProcessor } from '../dataSourceProcessor.service';
@@ -16,9 +15,8 @@ export interface IDataServiceFunction<TDataType> {
 export class DataServiceDataSource<TDataType> extends AsyncDataSource<TDataType> implements IAsyncDataSource<TDataType> {
 	constructor(getDataSet: IDataServiceFunction<TDataType>
 			, dataSourceProcessor: IDataSourceProcessor
-			, array: __array.IArrayUtility
-			, synchronizedRequestsFactory: __synchronizedRequests.ISynchronizedRequestsFactory) {
-		super(getDataSet, dataSourceProcessor, array, synchronizedRequestsFactory);
+			, array: __array.IArrayUtility) {
+		super(getDataSet, dataSourceProcessor, array);
 		this.countFilterGroups = true;
 
 		if (_.isFunction(getDataSet)) {

--- a/source/components/cardContainer/dataSources/serverSideDataSource/serverSideDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/serverSideDataSource/serverSideDataSource.service.tests.ts
@@ -5,7 +5,6 @@ import test = services.test;
 import fakeAsync = test.fakeAsync;
 import __object = services.object;
 import __array = services.array;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { ServerSideDataSource, IServerSideDataSource } from './serverSideDataSource.service';
 
@@ -47,12 +46,12 @@ describe('ServerSideDataSource', () => {
 			MergeSort,
 			services.UTILITY_PROVIDERS,
 		]);
-		inject([DataSourceProcessor, __array.ArrayUtility, __object.ObjectUtility, __synchronizedRequests.SynchronizedRequestsFactory]
-			, (_dataSourceProcessor, array, object, synchronizedRequestsFactory) => {
+		inject([DataSourceProcessor, __array.ArrayUtility, __object.ObjectUtility]
+			, (_dataSourceProcessor, array, object) => {
 
 			dataSourceProcessor = _dataSourceProcessor;
 			sinon.spy(dataSourceProcessor, 'processAndCount');
-			source = <any>new ServerSideDataSource<number>(dataService.get, <any>dataSourceProcessor, array, object, synchronizedRequestsFactory);
+			source = <any>new ServerSideDataSource<number>(dataService.get, <any>dataSourceProcessor, array, object);
 		})();
 
 		source.filters = <any>[filter];

--- a/source/components/cardContainer/dataSources/serverSideDataSource/serverSideDataSource.service.ts
+++ b/source/components/cardContainer/dataSources/serverSideDataSource/serverSideDataSource.service.ts
@@ -3,7 +3,6 @@ import * as _ from 'lodash';
 import { services, filters } from 'typescript-angular-utilities';
 import __array = services.array;
 import __object = services.object;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { IServerSearchFunction, IServerSearchParams, ISortParams, IPagingParams, IDataResult } from '../asyncTypes';
 import { IAsyncDataSource, AsyncDataSource, IDataSetFunction } from '../asyncDataSource.service';
@@ -18,9 +17,8 @@ export class ServerSideDataSource<TDataType> extends AsyncDataSource<TDataType> 
 	constructor(getDataSet: IServerSearchFunction<TDataType>
 			, dataSourceProcessor: IDataSourceProcessor
 			, array: __array.IArrayUtility
-			, private object: __object.IObjectUtility
-			, synchronizedRequestsFactory: __synchronizedRequests.ISynchronizedRequestsFactory) {
-		super(<any>getDataSet, dataSourceProcessor, array, synchronizedRequestsFactory);
+			, private object: __object.IObjectUtility) {
+		super(<any>getDataSet, dataSourceProcessor, array);
 	}
 
 	refresh(): void {

--- a/source/components/cardContainer/dataSources/smartDataSource/smartDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/smartDataSource/smartDataSource.service.tests.ts
@@ -5,7 +5,6 @@ import test = services.test;
 import fakeAsync = test.fakeAsync;
 import __object = services.object;
 import __array = services.array;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { SmartDataSource } from './smartDataSource.service';
 
@@ -80,14 +79,14 @@ describe('SmartDataSource', () => {
 			MergeSort,
 			services.UTILITY_PROVIDERS,
 		]);
-		inject([DataSourceProcessor, __array.ArrayUtility, __object.ObjectUtility, __synchronizedRequests.SynchronizedRequestsFactory]
-			, (_dataSourceProcessor, array, object, synchronizedRequestsFactory) => {
+		inject([DataSourceProcessor, __array.ArrayUtility, __object.ObjectUtility]
+			, (_dataSourceProcessor, array, object) => {
 
 			dataSourceProcessor = _dataSourceProcessor;
 			dataSourceProcessor.process = sinon.spy((data: any): any => { return { dataSet: data }; });
 			dataSourceProcessor.sort = sinon.spy();
 			dataSourceProcessor.page = sinon.spy();
-			source = new SmartDataSource<number>(dataService.get, <any>dataSourceProcessor, array, object, synchronizedRequestsFactory);
+			source = new SmartDataSource<number>(dataService.get, <any>dataSourceProcessor, array, object);
 		})();
 
 		source.filters = <any>[appliedFilter, unappliedFilter];

--- a/source/components/cardContainer/dataSources/smartDataSource/smartDataSource.service.ts
+++ b/source/components/cardContainer/dataSources/smartDataSource/smartDataSource.service.ts
@@ -4,7 +4,6 @@ import * as Rx from 'rxjs';
 import { services, filters, downgrade } from 'typescript-angular-utilities';
 import __array = services.array;
 import __object = services.object;
-import __synchronizedRequests = services.synchronizedRequests;
 
 import { IServerSearchFunction, IServerSearchParams, ISortParams, IPagingParams, IDataResult } from '../asyncTypes';
 import { IAsyncDataSource, AsyncDataSource, IDataSetFunction } from '../asyncDataSource.service';
@@ -25,9 +24,8 @@ export class SmartDataSource<TDataType> extends AsyncDataSource<TDataType> {
 	constructor(getDataSet: IServerSearchFunction<TDataType>
 			, dataSourceProcessor: IDataSourceProcessor
 			, array: __array.IArrayUtility
-			, private object: __object.IObjectUtility
-			, synchronizedRequestsFactory: __synchronizedRequests.ISynchronizedRequestsFactory) {
-		super(<any>getDataSet, dataSourceProcessor, array, synchronizedRequestsFactory);
+			, private object: __object.IObjectUtility) {
+		super(<any>getDataSet, dataSourceProcessor, array);
 	}
 
 	get filters(): filters.IFilter[] {

--- a/source/components/simpleCardList/simpleCard.tests.ts
+++ b/source/components/simpleCardList/simpleCard.tests.ts
@@ -18,11 +18,11 @@ describe('SimpleCardComponent', () => {
 			openCard: sinon.spy(() => true),
 		};
 
-		card = new SimpleCardComponent(<any>{}, null, null, null, <any>list);
+		card = new SimpleCardComponent(<any>{}, null, null, null, null, <any>list);
 	});
 
 	it('should create an empty list if no list is provided', (): void => {
-		card = new SimpleCardComponent(null, null, null, null, null);
+		card = new SimpleCardComponent(null, null, null, null, null, null);
 		expect(card.list).to.exist;
 	});
 
@@ -80,7 +80,7 @@ describe('SimpleCardComponent', () => {
 		});
 
 		it('should be able to open with an empty list', (): void => {
-			card = new SimpleCardComponent(null, null, null, null, null);
+			card = new SimpleCardComponent(null, null, null, null, null, null);
 			const onOpenSpy: Sinon.SinonSpy = sinon.spy();
 			card.onOpen.emit = onOpenSpy;
 			card.ngOnInit();

--- a/source/components/simpleCardList/simpleCard.ts
+++ b/source/components/simpleCardList/simpleCard.ts
@@ -39,6 +39,7 @@ export class SimpleCardComponent<T> extends FormComponent implements OnInit {
 			, asyncHelper: AsyncHelper
 			, formService: FormService
 			, @Optional() @SkipSelf() parentForm: FormComponent
+			, @Optional() nullInjectionConflictsWithCardParameter: AsyncHelper
 			, @Optional() @Inject(forwardRef(() => SimpleCardListComponent)) list: SimpleCardListComponent<T>) {
 		super(notification, asyncHelper, formService, parentForm);
 		this.list = list || this.emptyList();


### PR DESCRIPTION
This started as a spike, but I realized some valuable refactoring could be done without changing the external contract.

rxjs natively supports ignoring all but the latest request. Instead of injecting a service to handle this, we'll just convert any promises to observables and synchronize via rxjs. This removes a dependency and also allows us to support observable requests in addition to promises

Also included some bugfixes in the injections to simple card, card, and selectable card, which don't seem to be playing nicely with each other. 
