### PR TITLE
Add ability to enable/disable filter groups

### DIFF
--- a/bootstrapper/cards/cardsNg2.html
+++ b/bootstrapper/cards/cardsNg2.html
@@ -59,6 +59,7 @@
 	<rlFilterGroup [filterGroup]="filterGroup"></rlFilterGroup>
 	<rlFilterGroup [filterGroup]="modeFilterGroup"></rlFilterGroup>
 	<rlFilterGroup [filterGroup]="rangeFilterGroup"></rlFilterGroup>
+	<rlFilterGroup [filterGroup]="disabledFilterGroup" [enabled]="false"></rlFilterGroup>
 </div>
 <div>
 	<rlSelectFilter [filter]="selectFilter"

--- a/bootstrapper/cards/cardsNg2.html
+++ b/bootstrapper/cards/cardsNg2.html
@@ -59,7 +59,7 @@
 	<rlFilterGroup [filterGroup]="filterGroup"></rlFilterGroup>
 	<rlFilterGroup [filterGroup]="modeFilterGroup"></rlFilterGroup>
 	<rlFilterGroup [filterGroup]="rangeFilterGroup"></rlFilterGroup>
-	<rlFilterGroup [filterGroup]="disabledFilterGroup" [enabled]="false"></rlFilterGroup>
+	<rlFilterGroup [filterGroup]="disabledFilterGroup" [disabled]="true"></rlFilterGroup>
 </div>
 <div>
 	<rlSelectFilter [filter]="selectFilter"

--- a/bootstrapper/cards/cardsNg2Bootstrapper.ts
+++ b/bootstrapper/cards/cardsNg2Bootstrapper.ts
@@ -42,6 +42,7 @@ export class CardsBootstrapper {
 	filterGroup: FilterGroup;
 	modeFilterGroup: ModeFilterGroup;
 	rangeFilterGroup: RangeFilterGroup;
+	disabledFilterGroup: FilterGroup;
 	selectFilter: SelectFilter<any, any>;
 
 	constructor(timezone: __timezone.TimezoneService
@@ -130,6 +131,23 @@ export class CardsBootstrapper {
 			],
 		}, __object.objectUtility, __transform.transform);
 
+		this.disabledFilterGroup = new FilterGroup({
+			type: 'testGroup',
+			label: 'Disabled Filter Group',
+			options: [
+				{
+					label: 'Show',
+					filter: item => item.show,
+					serialize: () => 'show',
+				},
+				{
+					label: 'Hide',
+					filter: item => !item.show,
+					serialize: () => 'hide',
+				},
+			],
+		}, __object.objectUtility);
+
 		this.selectFilter = new SelectFilter({
 			valueSelector: 'value',
 		}, __object.objectUtility, __transform.transform);
@@ -138,6 +156,7 @@ export class CardsBootstrapper {
 		this.filterGroup.subscribe(value => console.log(value));
 		this.modeFilterGroup.subscribe(value => console.log(value));
 		this.rangeFilterGroup.subscribe(value => console.log(value));
+		this.disabledFilterGroup.subscribe(value => console.log(value));
 		this.selectFilter.subscribe(value => console.log(value));
 	}
 

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.component.html
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.component.html
@@ -1,4 +1,4 @@
-<div class="filter-group" [ngClass]="{'filter-disabled': !enabled}">
+<div class="filter-group" [ngClass]="{'filter-disabled': disabled}">
 	<div class="row filter-header" (click)="toggleExpanded()">
 		<div class="col-sm-12">
 			<i class="collapse-icon fa fa-caret-down fa-2x" [hidden]="!childrenVisible" title="Hide filter list"></i>

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.component.html
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.component.html
@@ -1,15 +1,15 @@
-<div class="filter-group">
-	<div class="row filter-header" (click)="toggleChildren()">
+<div class="filter-group" [ngClass]="{'filter-disabled': !enabled}">
+	<div class="row filter-header" (click)="toggleExpanded()">
 		<div class="col-sm-12">
-			<i class="collapse-icon fa fa-caret-down fa-2x" [hidden]="!showChildren" title="Hide filter list"></i>
-			<i class="collapse-icon fa fa-caret-right fa-2x" [hidden]="showChildren" title="Show filter list"></i>
+			<i class="collapse-icon fa fa-caret-down fa-2x" [hidden]="!childrenVisible" title="Hide filter list"></i>
+			<i class="collapse-icon fa fa-caret-right fa-2x" [hidden]="childrenVisible" title="Show filter list"></i>
 			<div class="filter-option">
 				<div style="display: inline-block" [hidden]="!icon" [innerHTML]="icon"></div>
-				<h4 style="display: inline-block">{{filterGroup.label}}: {{filterGroup.activeOption.label}}</h4>
+				<h4 style="display: inline-block">{{headerTitle}}</h4>
 			</div>
 		</div>
 	</div>
-	<div [hidden]="!showChildren" *ngFor="let filterOption of filterGroup?.options">
+	<div [hidden]="!childrenVisible" *ngFor="let filterOption of filterGroup?.options">
 		<rlFilterOption [option]="filterOption"
 						[isActive]="filterGroup.activeOption === filterOption"
 						(activate)="selectOption(filterOption)"></rlFilterOption>

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.component.tests.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.component.tests.ts
@@ -1,34 +1,68 @@
 import { FilterGroupComponent } from './filterGroup.component';
 
 describe('FilterGroupComponent', (): void => {
-	let filterGroup: FilterGroupComponent<any>;
+	let filterGroupComponent: FilterGroupComponent<any>;
+	let filterGroup = <any> {
+		label: 'some label',
+		activeOption: {
+			label: 'active option label'
+		}
+	};
 
 	beforeEach(() => {
-		filterGroup = new FilterGroupComponent(<any>{ log: sinon.spy() });
-		filterGroup.filterGroup = <any>{};
+		filterGroupComponent = new FilterGroupComponent(<any>{ log: sinon.spy() });
+		filterGroupComponent.filterGroup = filterGroup;
 	});
 
 	it('should toggle the children', (): void => {
-		expect(filterGroup.showChildren).to.be.true;
+		expect(filterGroupComponent.expanded).to.be.true;
 
-		filterGroup.toggleChildren();
+		filterGroupComponent.toggleExpanded();
 
-		expect(filterGroup.showChildren).to.be.false;
+		expect(filterGroupComponent.expanded).to.be.false;
 
-		filterGroup.toggleChildren();
+		filterGroupComponent.toggleExpanded();
 
-		expect(filterGroup.showChildren).to.be.true;
+		expect(filterGroupComponent.expanded).to.be.true;
+	});
+
+	it('should only show children if expanded and enabled', (): void => {
+		filterGroupComponent.expanded = true;
+		filterGroupComponent.enabled = false;
+		expect(filterGroupComponent.childrenVisible).to.be.false;
+
+		filterGroupComponent.expanded = false;
+		filterGroupComponent.enabled = true;
+		expect(filterGroupComponent.childrenVisible).to.be.false;
+
+		filterGroupComponent.expanded = false;
+		filterGroupComponent.enabled = false;
+		expect(filterGroupComponent.childrenVisible).to.be.false;
+
+		filterGroupComponent.expanded = true;
+		filterGroupComponent.enabled = true;
+		expect(filterGroupComponent.childrenVisible).to.be.true;
 	});
 
 	it('should set the active option and refresh the data source', (): void => {
 		const dataSource: any = { refresh: sinon.spy() };
-		filterGroup.dataSource = dataSource;
+		filterGroupComponent.dataSource = dataSource;
 		const option: any = { prop: 4 };
 
-		filterGroup.selectOption(option);
+		filterGroupComponent.selectOption(option);
 
 		sinon.assert.calledOnce(dataSource.refresh);
-		expect(filterGroup.filterGroup.activeOption).to.equal(option);
-		expect(filterGroup.showChildren).to.be.false;
+		expect(filterGroupComponent.filterGroup.activeOption).to.equal(option);
+		expect(filterGroupComponent.expanded).to.be.false;
+	});
+
+	it('should only show active option label if enabled', (): void => {
+		filterGroupComponent.enabled = true;
+		expect(filterGroupComponent.headerTitle).to.contain(filterGroup.label);
+		expect(filterGroupComponent.headerTitle).to.contain(filterGroup.activeOption.label);
+
+		filterGroupComponent.enabled = false;
+		expect(filterGroupComponent.headerTitle).to.contain(filterGroup.label);
+		expect(filterGroupComponent.headerTitle).to.not.contain(filterGroup.activeOption.label);
 	});
 });

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.component.tests.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.component.tests.ts
@@ -26,21 +26,21 @@ describe('FilterGroupComponent', (): void => {
 		expect(filterGroupComponent.expanded).to.be.true;
 	});
 
-	it('should only show children if expanded and enabled', (): void => {
+	it('should only show children if expanded and not disabled', (): void => {
 		filterGroupComponent.expanded = true;
-		filterGroupComponent.enabled = false;
+		filterGroupComponent.disabled = true;
 		expect(filterGroupComponent.childrenVisible).to.be.false;
 
 		filterGroupComponent.expanded = false;
-		filterGroupComponent.enabled = true;
+		filterGroupComponent.disabled = false;
 		expect(filterGroupComponent.childrenVisible).to.be.false;
 
 		filterGroupComponent.expanded = false;
-		filterGroupComponent.enabled = false;
+		filterGroupComponent.disabled = true;
 		expect(filterGroupComponent.childrenVisible).to.be.false;
 
 		filterGroupComponent.expanded = true;
-		filterGroupComponent.enabled = true;
+		filterGroupComponent.disabled = false;
 		expect(filterGroupComponent.childrenVisible).to.be.true;
 	});
 
@@ -56,12 +56,12 @@ describe('FilterGroupComponent', (): void => {
 		expect(filterGroupComponent.expanded).to.be.false;
 	});
 
-	it('should only show active option label if enabled', (): void => {
-		filterGroupComponent.enabled = true;
+	it('should not show active option label if disabled', (): void => {
+		filterGroupComponent.disabled = false;
 		expect(filterGroupComponent.headerTitle).to.contain(filterGroup.label);
 		expect(filterGroupComponent.headerTitle).to.contain(filterGroup.activeOption.label);
 
-		filterGroupComponent.enabled = false;
+		filterGroupComponent.disabled = true;
 		expect(filterGroupComponent.headerTitle).to.contain(filterGroup.label);
 		expect(filterGroupComponent.headerTitle).to.not.contain(filterGroup.activeOption.label);
 	});

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.component.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.component.ts
@@ -16,7 +16,7 @@ export class FilterGroupComponent<T> {
 	@Input() filterGroup: IFilterGroup;
 	@Input() dataSource: IDataSource<T>;
 	@Input() icon: string;
-	@Input() enabled: boolean = true;
+	@Input() disabled: boolean;
 
 	expanded: boolean = true;
 	logger: __logger.ILogger;
@@ -26,7 +26,7 @@ export class FilterGroupComponent<T> {
 	}
 
 	get headerTitle(): string {
-		if (this.enabled) {
+		if (!this.disabled) {
 			return this.filterGroup.label + ': ' + this.filterGroup.activeOption.label
 		}
 
@@ -38,7 +38,7 @@ export class FilterGroupComponent<T> {
 	}
 
 	get childrenVisible(): boolean {
-		return this.expanded && this.enabled;
+		return this.expanded && !this.disabled;
 	}
 
 	selectOption(option: IFilterOption): void {

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.component.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.component.ts
@@ -16,21 +16,34 @@ export class FilterGroupComponent<T> {
 	@Input() filterGroup: IFilterGroup;
 	@Input() dataSource: IDataSource<T>;
 	@Input() icon: string;
+	@Input() enabled: boolean = true;
 
-	showChildren: boolean = true;
+	expanded: boolean = true;
 	logger: __logger.ILogger;
 
 	constructor(logger: __logger.Logger) {
 		this.logger = logger;
 	}
 
-	toggleChildren(): void {
-		this.showChildren = !this.showChildren;
+	get headerTitle(): string {
+		if (this.enabled) {
+			return this.filterGroup.label + ': ' + this.filterGroup.activeOption.label
+		}
+
+		return this.filterGroup.label;
+	}
+
+	toggleExpanded(): void {
+		this.expanded = !this.expanded;
+	}
+
+	get childrenVisible(): boolean {
+		return this.expanded && this.enabled;
 	}
 
 	selectOption(option: IFilterOption): void {
 		this.filterGroup.activeOption = option;
-		this.showChildren = false;
+		this.expanded = false;
 
 		if (this.dataSource != null) {
 			this.dataSource.refresh();

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.html
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.html
@@ -1,4 +1,4 @@
-<div class="filter-group" ng-class="{'filter-disabled': !controller.enabled}">
+<div class="filter-group" ng-class="{'filter-disabled': controller.disabled}">
 	<div class="row filter-header" ng-click="controller.toggleExpanded()">
 		<div class="col-sm-12">
 			<i class="collapse-icon fa fa-caret-down fa-2x" ng-show="controller.childrenVisible" title="Hide filter list"></i>

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.html
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.html
@@ -1,15 +1,15 @@
-<div class="filter-group">
-	<div class="row filter-header" ng-click="controller.toggleChildren()">
+<div class="filter-group" ng-class="{'filter-disabled': !controller.enabled}">
+	<div class="row filter-header" ng-click="controller.toggleExpanded()">
 		<div class="col-sm-12">
-			<i class="collapse-icon fa fa-caret-down fa-2x" ng-show="controller.showChildren" title="Hide filter list"></i>
-			<i class="collapse-icon fa fa-caret-right fa-2x" ng-hide="controller.showChildren" title="Show filter list"></i>
+			<i class="collapse-icon fa fa-caret-down fa-2x" ng-show="controller.childrenVisible" title="Hide filter list"></i>
+			<i class="collapse-icon fa fa-caret-right fa-2x" ng-hide="controller.childrenVisible" title="Show filter list"></i>
 			<div class="filter-option">
 				<div style="display:inline-block" ng-show="controller.hasIcon" ng-bind-html="controller.icon"></div>
-				<h4 style="display: inline-block">{{controller.filterGroup.label}}: {{controller.filterGroup.activeOption.label}}</h4>
+				<h4 style="display: inline-block">{{controller.headerTitle}}</h4>
 			</div>
 		</div>
 	</div>
-	<div ng-show="controller.showChildren" ng-repeat="filterOption in controller.filterGroup.options">
+	<div ng-show="controller.childrenVisible" ng-repeat="filterOption in controller.filterGroup.options">
 		<rl-filter-option option="filterOption" active="filterGroup.activeOption === filterOption" activate="controller.selectOption(filterOption)"></rl-filter-option>
 	</div>
 </div>

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.ts
@@ -20,7 +20,7 @@ export class FilterGroupController {
 	icon: string;
 	filterGroup: IFilterGroup;
 	source: IDataSource<any>;
-	enabled: boolean;
+	disabled: boolean;
 
 	hasIcon: boolean;
 	expanded: boolean;
@@ -29,11 +29,10 @@ export class FilterGroupController {
 	constructor(private $scope: angular.IScope) {
 		this.hasIcon = this.icon != null && this.icon !== '';
 		this.expanded = true;
-		this.enabled = true;
 	}
 
 	get headerTitle(): string {
-		if (this.enabled) {
+		if (!this.disabled) {
 			return this.filterGroup.label + ': ' + this.filterGroup.activeOption.label
 		}
 
@@ -45,7 +44,7 @@ export class FilterGroupController {
 	}
 
 	get childrenVisible(): boolean {
-		return this.expanded && this.enabled;
+		return this.expanded && !this.disabled;
 	}
 
 	selectOption(option: IFilterOption): void {
@@ -68,6 +67,6 @@ export let filterGroup: angular.IComponentOptions = {
 		icon: '=',
 		filterGroup: '=',
 		source: '=',
-		enabled: '<',
+		disabled: '<',
 	},
 };

--- a/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.ts
+++ b/source/components/cardContainer/filters/filterGroup/filterGroup.directive.ng1.ts
@@ -20,23 +20,37 @@ export class FilterGroupController {
 	icon: string;
 	filterGroup: IFilterGroup;
 	source: IDataSource<any>;
+	enabled: boolean;
 
 	hasIcon: boolean;
-	showChildren: boolean;
+	expanded: boolean;
 
 	static $inject: string[] = ['$scope'];
 	constructor(private $scope: angular.IScope) {
 		this.hasIcon = this.icon != null && this.icon !== '';
-		this.showChildren = true;
+		this.expanded = true;
+		this.enabled = true;
 	}
 
-	toggleChildren(): void {
-		this.showChildren = !this.showChildren;
+	get headerTitle(): string {
+		if (this.enabled) {
+			return this.filterGroup.label + ': ' + this.filterGroup.activeOption.label
+		}
+
+		return this.filterGroup.label;
+	}
+
+	toggleExpanded(): void {
+		this.expanded = !this.expanded;
+	}
+
+	get childrenVisible(): boolean {
+		return this.expanded && this.enabled;
 	}
 
 	selectOption(option: IFilterOption): void {
 		this.filterGroup.activeOption = option;
-		this.showChildren = false;
+		this.expanded = false;
 
 		if (this.source != null) {
 			this.source.refresh();
@@ -54,5 +68,6 @@ export let filterGroup: angular.IComponentOptions = {
 		icon: '=',
 		filterGroup: '=',
 		source: '=',
+		enabled: '<',
 	},
 };


### PR DESCRIPTION
This adds the ability to supply an input to the `rlFilterGroup` component, determining whether it is enabled or not. If not enabled, the group is not expandable and only the group label displays in the header (active option label is hidden). I've also upgraded the NG2 version and added tests.

Completes https://renovo.myjetbrains.com/youtrack/issue/MUSIC-923
CSS changes will be included in https://renovo.myjetbrains.com/youtrack/issue/MUSIC-914 (but are not required to merge)

This is a non-breaking change as it defaults to enabled if not supplied.

![image](https://cloud.githubusercontent.com/assets/705898/17604601/8a01262c-5fe4-11e6-8b82-afc8fcb69e76.png)
