### PR TITLE
Add custom placeholder to card container search card

### DIFF
--- a/bootstrapper/cards/cardContainerBootstrapper.ts
+++ b/bootstrapper/cards/cardContainerBootstrapper.ts
@@ -19,6 +19,7 @@ class CardTestController {
 	builder: ICardContainerBuilder;
 	builderWithSelectFilter: ICardContainerBuilder;
 	builderWithDateFilter: ICardContainerBuilder;
+	builderWithSearch: ICardContainerBuilder;
 	options: number[];
 	selectFilter: ISelectFilter<number>;
 	dateFilter: IDateFilter;
@@ -71,6 +72,22 @@ class CardTestController {
 				},
 			],
 		});
+
+		this.builderWithSearch = cardContainerBuilderFactory.getInstance();
+		this.builderWithSearch.dataSource.buildSimpleDataSource(_.cloneDeep(items));
+		this.builder.usePaging();
+		this.builderWithSearch.addColumn({
+			label: 'Name',
+			size: 6,
+			getValue: 'name',
+		});
+		this.builderWithSearch.addColumn({
+			label: 'Value',
+			size: 6,
+			getValue: 'value',
+			template: '<b>{{myItem.value}}</b>',
+		});
+		this.builderWithSearch.useSearch();
 
 		this.builderWithSelectFilter = cardContainerBuilderFactory.getInstance();
 		this.dataSource = this.builderWithSelectFilter.dataSource.buildSimpleDataSource(_.cloneDeep(items));

--- a/bootstrapper/cards/cardsNg1.html
+++ b/bootstrapper/cards/cardsNg1.html
@@ -49,3 +49,12 @@
 		</rl-card-content>
 	</rl-card-container>
 </div>
+<div>
+	<label>Card container with search:</label>
+	<rl-card-container builder="cards.builderWithSearch" card-as="myItem" search-placeholder="'Custom Placeholder'">
+		<rl-card-content>
+			Name: {{myItem.name}}
+			Value: {{myItem.value}}
+		</rl-card-content>
+	</rl-card-container>
+</div>

--- a/bootstrapper/cards/cardsNg2.html
+++ b/bootstrapper/cards/cardsNg2.html
@@ -49,6 +49,17 @@
 	</rlSelectableCardContainer>
 </div>
 <div>
+	<label>Card container with search:</label>
+	<rlCardContainer [builder]="builder" [searchPlaceholder]="'Custom Placeholder'">
+		<div *rlColumnHeader="let value; name 'value'">Number</div>
+		<div *rlColumnContent="let value; name 'value'">#{{value}}</div>
+		<div *rlCardContent="let myItem">
+			Name: {{myItem.name}}
+			Value: {{myItem.value}}
+		</div>
+	</rlCardContainer>
+</div>
+<div>
 	<rlDateFilter [filter]="dateFilter"
 				  label="Date filter"
 				  showClear="true"

--- a/bootstrapper/cards/cardsNg2Bootstrapper.ts
+++ b/bootstrapper/cards/cardsNg2Bootstrapper.ts
@@ -74,6 +74,7 @@ export class CardsBootstrapper {
 			getValue: 'value',
 			template: '<b>{{myItem.value}}</b>',
 		});
+		this.builder.useSearch();
 
 		this.dateFilter = new DateFilter({
 			type: 'dateFilter',

--- a/source/components/cardContainer/cardContainer.ng1.ts
+++ b/source/components/cardContainer/cardContainer.ng1.ts
@@ -104,6 +104,7 @@ export class CardContainerController {
 	renderFilters: boolean;
 	saveWhenInvalid: boolean;
 	selectionChangedEvent: { (): void };
+	searchPlaceholder: string;
 
 	dataSource: IDataSource<any>;
 	sortDirection: ISortDirections;
@@ -381,5 +382,6 @@ export let cardContainer: angular.IComponentOptions = {
 		cardControllerAs: '@',
 		cardAs: '@',
 		selectionChangedEvent: '&selectionChanged',
+		searchPlaceholder: '<'
 	}
 }

--- a/source/components/cardContainer/cardContainer.ts
+++ b/source/components/cardContainer/cardContainer.ts
@@ -58,6 +58,9 @@ export class CardContainerComponent<T> implements OnInit {
 	builder: CardContainerBuilder;
 	save: ISaveAction<any>;
 
+	@Input()
+	searchPlaceholder: string;
+
 	dataSource: IDataSource<T>;
 	filters: filters.IFilter[];
 	searchFilter: __genericSearchFilter.IGenericSearchFilter;

--- a/source/components/cardContainer/cardContainer.ts
+++ b/source/components/cardContainer/cardContainer.ts
@@ -28,13 +28,7 @@ import { xs, sm, md, lg } from '../../services/breakpoints/breakpoint';
 
 import { ICardContainerBuilder, CardContainerBuilder, CardContainerType } from './builder/cardContainerBuilder.service';
 
-export interface ICardContainerInputs {
-	builder: string;
-	save: string;
-	searchPlaceholder: string;
-}
-
-export const cardContainerInputs: ICardContainerInputs = {
+export const cardContainerInputs = {
 	builder: 'builder',
 	save: 'save',
 	searchPlaceholder: 'searchPlaceholder'

--- a/source/components/cardContainer/cardContainer.ts
+++ b/source/components/cardContainer/cardContainer.ts
@@ -58,8 +58,7 @@ export class CardContainerComponent<T> implements OnInit {
 	builder: CardContainerBuilder;
 	save: ISaveAction<any>;
 
-	@Input()
-	searchPlaceholder: string;
+	@Input() searchPlaceholder: string;
 
 	dataSource: IDataSource<T>;
 	filters: filters.IFilter[];

--- a/source/components/cardContainer/cardContainer.ts
+++ b/source/components/cardContainer/cardContainer.ts
@@ -31,11 +31,13 @@ import { ICardContainerBuilder, CardContainerBuilder, CardContainerType } from '
 export interface ICardContainerInputs {
 	builder: string;
 	save: string;
+	searchPlaceholder: string;
 }
 
 export const cardContainerInputs: ICardContainerInputs = {
 	builder: 'builder',
 	save: 'save',
+	searchPlaceholder: 'searchPlaceholder'
 };
 
 export const defaultMaxColumnSorts: number = 2;
@@ -43,7 +45,11 @@ export const defaultMaxColumnSorts: number = 2;
 @Component({
 	selector: 'rlCardContainer',
 	template: require('./cardContainer.html'),
-	inputs: [cardContainerInputs.builder, cardContainerInputs.save],
+	inputs: [
+		cardContainerInputs.builder,
+		cardContainerInputs.save,
+		cardContainerInputs.searchPlaceholder
+	],
 	providers: [DataPager],
 	directives: [
 		ContainerHeaderComponent,
@@ -57,8 +63,7 @@ export const defaultMaxColumnSorts: number = 2;
 export class CardContainerComponent<T> implements OnInit {
 	builder: CardContainerBuilder;
 	save: ISaveAction<any>;
-
-	@Input() searchPlaceholder: string;
+	searchPlaceholder: string;
 
 	dataSource: IDataSource<T>;
 	filters: filters.IFilter[];

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ng1.tests.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ng1.tests.ts
@@ -20,6 +20,7 @@ interface ISearchFilterMock {
 
 interface ICardContainerMock {
 	searchFilter: any;
+	searchPlaceholder: any;
 	dataSource: any;
 }
 
@@ -47,6 +48,7 @@ describe('CardSearchController', () => {
 
 		cardContainer = {
 			searchFilter: filter,
+			searchPlaceholder: null,
 			dataSource: {
 				refresh: refreshSpy,
 			},
@@ -73,6 +75,12 @@ describe('CardSearchController', () => {
 		let filter: any = {};
 		buildController();
 		expect(cardSearch.searchPlaceholder).to.equal(defaultSearchPlaceholder);
+	});
+
+	it('should lookup the search placeholder from the card container', (): void => {
+		buildController();
+		cardContainer.searchPlaceholder = 'custom placeholder';
+		expect(cardSearch.searchPlaceholder).to.equal(cardContainer.searchPlaceholder);
 	});
 
 	describe('search', (): void => {

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ng1.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ng1.ts
@@ -20,7 +20,6 @@ export class CardSearchController {
 	// bindings
 	delay: number;
 
-	searchPlaceholder: string;
 	searchLengthError: boolean = false;
 	minSearchLength: number;
 	hasSearchFilter: boolean = true;
@@ -71,8 +70,6 @@ export class CardSearchController {
 		}
 
 		if (this.hasSearchFilter) {
-			this.searchPlaceholder = defaultSearchPlaceholder;
-
 			this.delay = this.delay != null
 				? this.delay
 				: defaultSearchDelay;
@@ -80,6 +77,12 @@ export class CardSearchController {
 			this.searchFilter.subscribe((): void => {
 				this.searchText = this.searchFilter.searchText;
 			});
+		}
+	}
+
+	get searchPlaceholder(): string {
+		if (this.hasSearchFilter) {
+			return this.cardContainer.searchPlaceholder || defaultSearchPlaceholder;
 		}
 	}
 

--- a/source/components/cardContainer/container/cardSearch/cardSearch.tests.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.tests.ts
@@ -16,6 +16,7 @@ interface ISearchFilterMock {
 
 interface ICardContainerMock {
 	searchFilter: any;
+	searchPlaceholder: any;
 	dataSource: any;
 }
 
@@ -39,6 +40,7 @@ describe('CardSearchComponent', () => {
 
 		cardContainer = {
 			searchFilter: filter,
+			searchPlaceholder: null,
 			dataSource: {
 				refresh: refreshSpy,
 			},
@@ -65,6 +67,12 @@ describe('CardSearchComponent', () => {
 		cardSearch.searchFilter = filter;
 		cardSearch.ngOnInit();
 		expect(cardSearch.searchPlaceholder).to.equal(defaultSearchPlaceholder);
+	});
+
+	it('should lookup the search placeholder from the card container', (): void => {
+		cardSearch.ngOnInit();
+		cardContainer.searchPlaceholder = 'custom placeholder';
+		expect(cardSearch.searchPlaceholder).to.equal(cardContainer.searchPlaceholder);
 	});
 
 	describe('search', (): void => {

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ts
@@ -23,7 +23,6 @@ export class CardSearchComponent<T> implements OnInit {
 	@Input() delay: number;
 	@Input() searchFilter: __genericSearchFilter.IGenericSearchFilter;
 
-	searchPlaceholder: string;
 	searchLengthError: boolean = false;
 	hasSearchFilter: boolean = true;
 	minSearchError: string;
@@ -62,11 +61,15 @@ export class CardSearchComponent<T> implements OnInit {
 		}
 
 		if (this.hasSearchFilter) {
-			this.searchPlaceholder = defaultSearchPlaceholder;
-
 			this.delay = this.delay || defaultSearchDelay;
 		}
 	}
+
+	get searchPlaceholder(): string {
+ 		if (this.hasSearchFilter) {
+ 			return this.cardContainer.searchPlaceholder || defaultSearchPlaceholder;
+ 		}
+ 	}
 
 	private validateSearchLength(search: string, minLength: number): void {
 		// show error if search string exists but is below minimum size

--- a/source/components/cardContainer/selectableCardContainer.ts
+++ b/source/components/cardContainer/selectableCardContainer.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, Provider, forwardRef, ContentChild, ContentChildren, QueryList } from '@angular/core';
+import { Component, Output, EventEmitter, Provider, forwardRef, ContentChild, ContentChildren, QueryList } from '@angular/core';
 import { each, isUndefined, filter, difference } from 'lodash';
 
 import { services, filters } from 'typescript-angular-utilities';
@@ -39,7 +39,7 @@ export interface ISelectionViewData {
 @Component({
 	selector: 'rlSelectableCardContainer',
 	template: require('./selectableCardContainer.html'),
-	inputs: [cardContainerInputs.builder, cardContainerInputs.save],
+	inputs: [cardContainerInputs.builder, cardContainerInputs.save, cardContainerInputs.searchPlaceholder],
 	providers: [
 		DataPager,
 		new Provider(CardContainerComponent, {
@@ -57,7 +57,6 @@ export interface ISelectionViewData {
 	pipes: [__isEmpty.IsEmptyPipe],
 })
 export class SelectableCardContainerComponent<T extends ISelectableItem> extends CardContainerComponent<T> {
-	@Input() searchPlaceholder: string;
 	@Output() selectionChanged: EventEmitter<void> = new EventEmitter<void>();
 
 	selectionColumn: IColumn<any>;

--- a/source/components/cardContainer/selectableCardContainer.ts
+++ b/source/components/cardContainer/selectableCardContainer.ts
@@ -39,7 +39,11 @@ export interface ISelectionViewData {
 @Component({
 	selector: 'rlSelectableCardContainer',
 	template: require('./selectableCardContainer.html'),
-	inputs: [cardContainerInputs.builder, cardContainerInputs.save, cardContainerInputs.searchPlaceholder],
+	inputs: [
+		cardContainerInputs.builder,
+		cardContainerInputs.save,
+		cardContainerInputs.searchPlaceholder
+	],
 	providers: [
 		DataPager,
 		new Provider(CardContainerComponent, {

--- a/source/components/cardContainer/selectableCardContainer.ts
+++ b/source/components/cardContainer/selectableCardContainer.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, Provider, forwardRef, ContentChild, ContentChildren, QueryList } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Provider, forwardRef, ContentChild, ContentChildren, QueryList } from '@angular/core';
 import { each, isUndefined, filter, difference } from 'lodash';
 
 import { services, filters } from 'typescript-angular-utilities';
@@ -57,6 +57,7 @@ export interface ISelectionViewData {
 	pipes: [__isEmpty.IsEmptyPipe],
 })
 export class SelectableCardContainerComponent<T extends ISelectableItem> extends CardContainerComponent<T> {
+	@Input() searchPlaceholder: string;
 	@Output() selectionChanged: EventEmitter<void> = new EventEmitter<void>();
 
 	selectionColumn: IColumn<any>;


### PR DESCRIPTION
This adds (or rather just exposes) the card search placeholder text to the card container input bindings so consuming pages can customize the text. This is a non-breaking change since it still falls back to the default placeholder text.

Completes https://renovo.myjetbrains.com/youtrack/issue/MUSIC-924

![image](https://cloud.githubusercontent.com/assets/705898/17672713/b88d3328-62eb-11e6-85bd-b891e1542aaa.png)
