### PR TITLE
Added tests for the search stream behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rxjs": "5.0.0-beta.6",
     "signature_pad": "~1.5.3",
     "systemjs": "^0.19.28",
-    "typescript-angular-utilities": "~3.3.6",
+    "typescript-angular-utilities": "~3.3.9",
     "ui-select": "~0.14.7",
     "zone.js": "^0.6.12"
   },

--- a/source/behaviors/autosave/autosave.tests.ts
+++ b/source/behaviors/autosave/autosave.tests.ts
@@ -2,8 +2,8 @@ import { Subject } from 'rxjs';
 
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
-import fakeAsync = __test.fakeAsync;
-import tick = __test.tick;
+import rlFakeAsync = __test.rlFakeAsync;
+import rlTick = __test.rlTick;
 import flushMicrotasks = __test.flushMicrotasks;
 
 import { AutosaveDirective, DEFAULT_AUTOSAVE_DEBOUNCE } from './autosave';
@@ -48,43 +48,43 @@ describe('AutosaveDirective', () => {
 	});
 
 	describe('setDebounce', () => {
-		it('should set a timer to autosave after the specified duration', fakeAsync((): void => {
+		it('should set a timer to autosave after the specified duration', rlFakeAsync((): void => {
 			const autosaveSpy = sinon.spy();
 			autosave.autosave = autosaveSpy;
 
 			autosave.setDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE);
 			flushMicrotasks();
 
 			sinon.assert.calledOnce(autosaveSpy);
 		}));
 
-		it('should only autosave once if called again while the timer is in progress', fakeAsync(() => {
+		it('should only autosave once if called again while the timer is in progress', rlFakeAsync(() => {
 			const autosaveSpy = sinon.spy();
 			autosave.autosave = autosaveSpy;
 
 			autosave.setDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
 			flushMicrotasks();
 
 			autosave.setDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE);
 			flushMicrotasks();
 
 			sinon.assert.calledOnce(autosaveSpy);
 		}));
 
-		it('should not trigger an autosave if the form is invalid', fakeAsync(() => {
+		it('should not trigger an autosave if the form is invalid', rlFakeAsync(() => {
 			const autosaveSpy = sinon.spy();
 			autosave.autosave = autosaveSpy;
 			form.validate = sinon.spy(() => false);
 
 			autosave.setDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE);
 			flushMicrotasks();
 
 			sinon.assert.notCalled(autosaveSpy);
@@ -92,35 +92,35 @@ describe('AutosaveDirective', () => {
 	});
 
 	describe('resetDebounce', () => {
-		it('should reset the timer for autosaving', fakeAsync(() => {
+		it('should reset the timer for autosaving', rlFakeAsync(() => {
 			const autosaveSpy = sinon.spy();
 			autosave.autosave = autosaveSpy;
 
 			autosave.setDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
 			flushMicrotasks();
 
 			autosave.resetDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
 			flushMicrotasks();
 
 			sinon.assert.notCalled(autosaveSpy);
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE / 2);
 			flushMicrotasks();
 
 			sinon.assert.calledOnce(autosaveSpy);
 		}));
 
-		it('should do nothing if no timer is in progress', fakeAsync(() => {
+		it('should do nothing if no timer is in progress', rlFakeAsync(() => {
 			const autosaveSpy = sinon.spy();
 			autosave.autosave = autosaveSpy;
 
 			autosave.resetDebounce();
 
-			tick(DEFAULT_AUTOSAVE_DEBOUNCE);
+			rlTick(DEFAULT_AUTOSAVE_DEBOUNCE);
 			flushMicrotasks();
 
 			sinon.assert.notCalled(autosaveSpy);

--- a/source/components/busy/busy.tests.ts
+++ b/source/components/busy/busy.tests.ts
@@ -3,7 +3,7 @@ import { Subject } from 'rxjs';
 import { services } from 'typescript-angular-utilities';
 import IMockedPromise = services.test.IMockedPromise;
 import mock = services.test.mock;
-import fakeAsync = services.test.fakeAsync;
+import rlFakeAsync = services.test.rlFakeAsync;
 
 import { BusyComponent } from './busy';
 import { AsyncHelper } from '../../services/async/async.service';

--- a/source/components/buttons/buttonAsync/buttonAsync.ng1.tests.ts
+++ b/source/components/buttons/buttonAsync/buttonAsync.ng1.tests.ts
@@ -4,7 +4,7 @@ import 'angular-mocks';
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
 import mock = __test.mock;
-import fakeAsync = __test.fakeAsync;
+import rlFakeAsync = __test.rlFakeAsync;
 import IMockedPromise = __test.IMockedPromise;
 
 import { ButtonAsyncController, moduleName, controllerName } from './buttonAsync.ng1';
@@ -28,7 +28,7 @@ describe('ButtonAsyncController', () => {
 	});
 
 	describe('should finish', (): void => {
-		it('when promise resolves', fakeAsync((): void => {
+		it('when promise resolves', rlFakeAsync((): void => {
 			actionSpy = mock.promise();
 			button = buildController();
 
@@ -41,7 +41,7 @@ describe('ButtonAsyncController', () => {
 			expect(button.busy).to.be.false;
 		}));
 
-		it('when promise rejects', fakeAsync((): void => {
+		it('when promise rejects', rlFakeAsync((): void => {
 			const fakeError = 'fakeError';
 			actionSpy = mock.rejectedPromise(fakeError);
 			button = buildController();

--- a/source/components/buttons/buttonLongClick/buttonLongClick.tests.ts
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.tests.ts
@@ -1,7 +1,7 @@
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
-import fakeAsync = __test.fakeAsync;
-import tick = __test.tick;
+import rlFakeAsync = __test.rlFakeAsync;
+import rlTick = __test.rlTick;
 import flushMicrotasks = __test.flushMicrotasks;
 import __timeout = services.timeout;
 
@@ -34,7 +34,7 @@ describe('ButtonLongClickComponent', () => {
 		button.busySpinner = <any>busy;
 	});
 
-	it('should trigger the action after 2 seconds', fakeAsync((): void => {
+	it('should trigger the action after 2 seconds', rlFakeAsync((): void => {
 		action = sinon.spy(() => 5);
 		button.action = action;
 		const event: any = { value: 2 };
@@ -43,7 +43,7 @@ describe('ButtonLongClickComponent', () => {
 
 		sinon.assert.notCalled(action);
 
-		tick(2000);
+		rlTick(2000);
 		flushMicrotasks();
 
 		sinon.assert.calledOnce(action);
@@ -52,7 +52,7 @@ describe('ButtonLongClickComponent', () => {
 		sinon.assert.calledWith(busy.trigger, 5);
 	}));
 
-	it('should cancel and show a warning if the user stops the action before the time is up', fakeAsync((): void => {
+	it('should cancel and show a warning if the user stops the action before the time is up', rlFakeAsync((): void => {
 		action = sinon.spy(() => 5);
 		button.action = action;
 		const event: any = { value: 2 };
@@ -60,7 +60,7 @@ describe('ButtonLongClickComponent', () => {
 
 		button.startAction(event);
 
-		tick(1000);
+		rlTick(1000);
 
 		button.stopAction();
 		flushMicrotasks();
@@ -68,7 +68,7 @@ describe('ButtonLongClickComponent', () => {
 		sinon.assert.calledOnce(notification.warning);
 		sinon.assert.calledWith(notification.warning, 'warning');
 
-		tick(1000);
+		rlTick(1000);
 		flushMicrotasks();
 
 		sinon.assert.notCalled(action);

--- a/source/components/cardContainer/card/headerColumn/headerColumn.tests.ts
+++ b/source/components/cardContainer/card/headerColumn/headerColumn.tests.ts
@@ -1,0 +1,64 @@
+import { CardHeaderColumnComponent } from './headerColumn';
+
+interface ITransformMock {
+	getValue: Sinon.SinonSpy;
+}
+
+interface ISizeForBreakpointsMock {
+	getClass: Sinon.SinonSpy;
+}
+
+describe('CardHeaderColumnComponent', () => {
+	let headerColumn: CardHeaderColumnComponent<number>;
+	let transform: ITransformMock;
+	let sizeForBreakpoints: any;
+
+	beforeEach(() => {
+		transform = {
+			getValue: sinon.spy(),
+		};
+		sizeForBreakpoints = {
+			getClass: sinon.spy(),
+		};
+		headerColumn = new CardHeaderColumnComponent<number>(transform, sizeForBreakpoints);
+		headerColumn.column = <any>{};
+	});
+
+	it('should transform the item to a value', () => {
+		const item = 4;
+		const column = { getValue: () => null };
+		const value = 6;
+		headerColumn.item = item;
+		headerColumn.column = <any>column;
+		transform.getValue = sinon.spy(() => value);
+
+		expect(headerColumn.value).to.equal(value);
+		sinon.assert.calledOnce(transform.getValue);
+		sinon.assert.calledWith(transform.getValue, item, column.getValue);
+	});
+
+	it('should build a context object for ngOutletContext', () => {
+		headerColumn.item = 4;
+		const value = 6;
+		transform.getValue = sinon.spy(() => value);
+
+		const context = headerColumn.context;
+
+		expect(context.$implicit).to.equal(value);
+		expect(context.item).to.equal(headerColumn.item);
+	});
+
+	it('should set the sizeClass based on the column size settings', () => {
+		headerColumn.column = <any>{
+			size: 3,
+			styling: 'my-class',
+		};
+		sizeForBreakpoints.getClass = sinon.spy(() => 'test-class');
+
+		headerColumn.ngOnInit();
+
+		sinon.assert.calledOnce(sizeForBreakpoints.getClass);
+		sinon.assert.calledWith(sizeForBreakpoints.getClass, 3, 'my-class');
+		expect(headerColumn.sizeClass).to.equal('test-class');
+	});
+});

--- a/source/components/cardContainer/card/headerColumn/headerColumn.tests.ts
+++ b/source/components/cardContainer/card/headerColumn/headerColumn.tests.ts
@@ -11,7 +11,7 @@ interface ISizeForBreakpointsMock {
 describe('CardHeaderColumnComponent', () => {
 	let headerColumn: CardHeaderColumnComponent<number>;
 	let transform: ITransformMock;
-	let sizeForBreakpoints: any;
+	let sizeForBreakpoints: ISizeForBreakpointsMock;
 
 	beforeEach(() => {
 		transform = {
@@ -20,7 +20,7 @@ describe('CardHeaderColumnComponent', () => {
 		sizeForBreakpoints = {
 			getClass: sinon.spy(),
 		};
-		headerColumn = new CardHeaderColumnComponent<number>(transform, sizeForBreakpoints);
+		headerColumn = new CardHeaderColumnComponent<number>(transform, <any>sizeForBreakpoints);
 		headerColumn.column = <any>{};
 	});
 

--- a/source/components/cardContainer/card/headerColumn/headerColumn.ts
+++ b/source/components/cardContainer/card/headerColumn/headerColumn.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Inject, forwardRef, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { services } from 'typescript-angular-utilities';
 import __transform = services.transform;
@@ -6,7 +6,6 @@ import __transform = services.transform;
 import { IColumn } from '../../column';
 import { ColumnContentTemplate } from '../../templates/columnContent.template';
 import { SizeForBreakpoints } from './sizeForBreakpoints';
-import { CardComponent } from '../card';
 
 @Component({
 	selector: 'rlCardHeaderColumn',
@@ -31,14 +30,11 @@ export class CardHeaderColumnComponent<T> implements OnInit {
 
 	sizeClass: string;
 
-	card: CardComponent<T>
 	transformService: __transform.ITransformService;
 	sizeForBreakpoints: SizeForBreakpoints;
 
-	constructor(@Inject(forwardRef(() => CardComponent)) card: CardComponent<T>
-			, transformService: __transform.TransformService
+	constructor(transformService: __transform.TransformService
 			, sizeForBreakpoints: SizeForBreakpoints) {
-		this.card = card;
 		this.transformService = transformService;
 		this.sizeForBreakpoints = sizeForBreakpoints;
 	}

--- a/source/components/cardContainer/card/headerColumn/sizeForBreakpoints.tests.ts
+++ b/source/components/cardContainer/card/headerColumn/sizeForBreakpoints.tests.ts
@@ -1,0 +1,42 @@
+import { SizeForBreakpoints } from './sizeForBreakpoints';
+
+import { services } from 'typescript-angular-utilities';
+import __string = services.string;
+
+describe('SizeForBreakpoints', () => {
+	let sizeForBreakpoints: SizeForBreakpoints;
+
+	beforeEach(() => {
+		sizeForBreakpoints = new SizeForBreakpoints(__string.stringUtility);
+	});
+
+	it('should convert an object of breakpoint sizes into a class string', () => {
+		const sizes = {
+			lg: 4,
+			md: 3,
+			sm: 2,
+			xs: 1,
+		};
+		expect(sizeForBreakpoints.getClass(sizes, '')).to.equal('col-xs-1 col-sm-2 col-md-3 col-lg-4 ');
+	});
+
+	it('should specify hidden for sizes that are not present', () => {
+		const sizes = {
+			lg: 4,
+			md: 3,
+			sm: 0,
+			xs: 0,
+		};
+		expect(sizeForBreakpoints.getClass(sizes, '')).to.equal('hidden-xs hidden-sm col-md-3 col-lg-4 ');
+	});
+
+	it('should append custom styling to the end of the class string', () => {
+		const sizes = {
+			lg: 1,
+			md: 1,
+			sm: 1,
+			xs: 1,
+		};
+		expect(sizeForBreakpoints.getClass(sizes, 'my-class')).to.equal('col-xs-1 col-sm-1 col-md-1 col-lg-1 my-class');
+	});
+});

--- a/source/components/cardContainer/container/cardSearch/cardSearch.tests.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.tests.ts
@@ -1,7 +1,7 @@
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
-import fakeAsync = __test.fakeAsync;
-import tick = __test.tick;
+import rlFakeAsync = __test.rlFakeAsync;
+import rlTick = __test.rlTick;
 import flushMicrotasks = __test.flushMicrotasks;
 import __timeout = services.timeout;
 
@@ -82,42 +82,42 @@ describe('CardSearchComponent', () => {
 			expect(filter.searchText).to.equal('search');
 		});
 
-		it('should refresh the data source after a delay of the specified duration', fakeAsync((): void => {
+		it('should refresh the data source after a delay of the specified duration', rlFakeAsync((): void => {
 			cardSearch.delay = 10;
 			cardSearch.setSearch('search');
 
 			sinon.assert.notCalled(refreshSpy);
 
-			tick(5)
+			rlTick(5)
 			flushMicrotasks();
 
 			sinon.assert.notCalled(refreshSpy);
 
-			tick(5);
+			rlTick(5);
 			flushMicrotasks();
 
 			sinon.assert.calledOnce(refreshSpy);
 		}));
 
-		it('should reset the timer if the search text changes', fakeAsync((): void => {
+		it('should reset the timer if the search text changes', rlFakeAsync((): void => {
 			cardSearch.delay = 10;
 			cardSearch.setSearch('search');
 
 			sinon.assert.notCalled(refreshSpy);
 
-			tick(5);
+			rlTick(5);
 			flushMicrotasks();
 
 			sinon.assert.notCalled(refreshSpy);
 
 			cardSearch.setSearch('search 2');
 
-			tick(5);
+			rlTick(5);
 			flushMicrotasks();
 
 			sinon.assert.notCalled(refreshSpy);
 
-			tick(5);
+			rlTick(5);
 			flushMicrotasks();
 
 			sinon.assert.calledOnce(refreshSpy);

--- a/source/components/cardContainer/container/columnHeader/columnHeader.tests.ts
+++ b/source/components/cardContainer/container/columnHeader/columnHeader.tests.ts
@@ -1,0 +1,31 @@
+import { ColumnHeaderComponent } from './columnHeader';
+
+interface ISizeForBreakpointsMock {
+	getClass: Sinon.SinonSpy;
+}
+
+describe('ColumnHeaderComponent', () => {
+	let columnHeader: ColumnHeaderComponent<number>;
+	let sizeForBreakpoints: ISizeForBreakpointsMock;
+
+	beforeEach(() => {
+		sizeForBreakpoints = {
+			getClass: sinon.spy(),
+		};
+		columnHeader = new ColumnHeaderComponent<number>(<any>sizeForBreakpoints);
+	});
+
+	it('should set the sizeClass based on the column size settings', () => {
+		columnHeader.column = <any>{
+			size: 3,
+			styling: 'my-class',
+		};
+		sizeForBreakpoints.getClass = sinon.spy(() => 'test-class');
+
+		columnHeader.ngOnInit();
+
+		sinon.assert.calledOnce(sizeForBreakpoints.getClass);
+		sinon.assert.calledWith(sizeForBreakpoints.getClass, 3, 'my-class');
+		expect(columnHeader.sizeClass).to.equal('test-class');
+	});
+});

--- a/source/components/cardContainer/container/itemCount/itemCount.html
+++ b/source/components/cardContainer/container/itemCount/itemCount.html
@@ -1,3 +1,3 @@
-<p [hidden]="cardContainer?.dataSource?.loadingDataSet">
-	Showing <strong>{{cardContainer?.dataSource?.dataSet?.length}} of {{cardContainer?.dataSource?.count}}</strong> total items
+<p [hidden]="loadingDataSet">
+	Showing <strong>{{visibleCount}} of {{totalCount}}</strong> total items
 </p>

--- a/source/components/cardContainer/container/itemCount/itemCount.tests.ts
+++ b/source/components/cardContainer/container/itemCount/itemCount.tests.ts
@@ -1,0 +1,36 @@
+import { ItemCountComponent } from './itemCount';
+
+interface ICardContainerMock {
+	dataSource: {
+		loadingDataSet?: boolean;
+		dataSet?: { length: number };
+		count?: number;
+	};
+}
+
+describe('ItemCountComponent', () => {
+	let itemCount: ItemCountComponent<number>;
+	let cardContainer: ICardContainerMock;
+
+	beforeEach(() => {
+		cardContainer = {
+			dataSource: {},
+		};
+		itemCount = new ItemCountComponent<number>(<any>cardContainer);
+	});
+
+	it('should get the data source loading property', () => {
+		cardContainer.dataSource.loadingDataSet = true;
+		expect(itemCount.loadingDataSet).to.be.true;
+	});
+
+	it('should get the count of visible items', () => {
+		cardContainer.dataSource.dataSet = [1, 2, 3];
+		expect(itemCount.visibleCount).to.equal(3);
+	});
+
+	it('should get the total count from the data source', () => {
+		cardContainer.dataSource.count = 5;
+		expect(itemCount.totalCount).to.equal(5);
+	});
+});

--- a/source/components/cardContainer/container/itemCount/itemCount.ts
+++ b/source/components/cardContainer/container/itemCount/itemCount.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, forwardRef } from '@angular/core';
 
 import { CardContainerComponent } from '../../cardContainer';
+import { IDataSource } from '../../dataSources/index';
 
 @Component({
 	selector: 'rlItemCount',
@@ -8,6 +9,30 @@ import { CardContainerComponent } from '../../cardContainer';
 })
 export class ItemCountComponent<T> {
 	cardContainer: CardContainerComponent<T>;
+
+	get dataSource(): IDataSource<T> {
+		return this.cardContainer && this.cardContainer.dataSource
+			? this.cardContainer.dataSource
+			: null;
+	}
+
+	get loadingDataSet(): boolean {
+		return this.dataSource
+			? this.dataSource.loadingDataSet
+			: false;
+	}
+
+	get visibleCount(): number {
+		return this.dataSource && this.dataSource.dataSet
+			? this.dataSource.dataSet.length
+			: null;
+	}
+
+	get totalCount(): number {
+		return this.dataSource
+			? this.dataSource.count
+			: null;
+	}
 
 	constructor(@Inject(forwardRef(() => CardContainerComponent)) cardContainer: CardContainerComponent<T>) {
 		this.cardContainer = cardContainer;

--- a/source/components/cardContainer/dataSources/asyncDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/asyncDataSource.service.tests.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 import __array = services.array;
 
 import { AsyncDataSource, IDataSource } from './asyncDataSource.service';
@@ -48,7 +48,7 @@ describe('AsyncDataSource', () => {
 		source.processData = sinon.spy();
 	});
 
-	it('should call make a request to get the data when reload is called', fakeAsync((): void => {
+	it('should call make a request to get the data when reload is called', rlFakeAsync((): void => {
 		source.reload();
 
 		sinon.assert.calledOnce(dataService.get);
@@ -58,7 +58,7 @@ describe('AsyncDataSource', () => {
 		sinon.assert.calledOnce(<Sinon.SinonSpy>source.processData);
 	}));
 
-	it('should fire changed, reloaded, and redrawing events when the reload completeds', fakeAsync((): void => {
+	it('should fire changed, reloaded, and redrawing events when the reload completeds', rlFakeAsync((): void => {
 		source.reload();
 		test.mock.flushAll(dataService);
 		sinon.assert.calledOnce(changedSpy);
@@ -74,7 +74,7 @@ describe('AsyncDataSource', () => {
 	});
 
 	describe('synchronization', () => {
-		it('should synchronize the promises', fakeAsync(() => {
+		it('should synchronize the promises', rlFakeAsync(() => {
 			const firstRequest = test.mock.promise([1, 2]);
 			source.getDataSet = firstRequest;
 			source.reload();
@@ -92,7 +92,7 @@ describe('AsyncDataSource', () => {
 			expect(source.rawDataSet).to.deep.equal([3, 4]);
 		}));
 
-		it('should synchronize the requests', fakeAsync(() => {
+		it('should synchronize the requests', rlFakeAsync(() => {
 			const firstRequest = test.mock.request([1, 2]);
 			source.getDataSet = firstRequest;
 			source.reload();

--- a/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/clientServerDataSource/clientServerDataSource.service.tests.ts
@@ -2,7 +2,7 @@ import { addProviders, inject } from '@angular/core/testing';
 
 import { services } from 'typescript-angular-utilities';
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 import __genericSearchFilter = services.genericSearchFilter;
 import __object = services.object;
 import __array = services.array;
@@ -69,7 +69,7 @@ describe('ClientServerDataSource', () => {
 			source.changed.subscribe(changedSpy);
 		}));
 
-		it('should call data processor to process the data when refreshing', fakeAsync((): void => {
+		it('should call data processor to process the data when refreshing', rlFakeAsync((): void => {
 			searchFilter.searchText = 'search';
 			source.reload();
 
@@ -78,7 +78,7 @@ describe('ClientServerDataSource', () => {
 			sinon.assert.calledOnce(<Sinon.SinonSpy>dataSourceProcessor.processAndCount);
 		}));
 
-		it('should make a request to reload the data when the search text changes', fakeAsync((): void => {
+		it('should make a request to reload the data when the search text changes', rlFakeAsync((): void => {
 			searchFilter.searchText = 'search';
 			source.refresh();
 
@@ -147,7 +147,7 @@ describe('ClientServerDataSource', () => {
 			source.changed.subscribe(changedSpy);
 		}));
 
-		it('should make a request to reload the data when the filter model changes', fakeAsync((): void => {
+		it('should make a request to reload the data when the filter model changes', rlFakeAsync((): void => {
 			filterModel = { prop: '123' };
 			source.refresh();
 

--- a/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/dataServiceDataSource/dataServiceDataSource.service.tests.ts
@@ -2,7 +2,7 @@ import { addProviders, inject } from '@angular/core/testing';
 
 import { services } from 'typescript-angular-utilities';
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 import __object = services.object;
 import __array = services.array;
 
@@ -42,7 +42,7 @@ describe('DataServiceDataSource', () => {
 	});
 
 	describe('loading', (): void => {
-		it('should call data processor to process the data when refreshing', fakeAsync((): void => {
+		it('should call data processor to process the data when refreshing', rlFakeAsync((): void => {
 			dataService.get = test.mock.promise([1, 2, 3]);
 
 			new DataServiceDataSource(dataService.get, dataSourceProcessor, arrayUtility);
@@ -51,7 +51,7 @@ describe('DataServiceDataSource', () => {
 			sinon.assert.calledOnce(<Sinon.SinonSpy>dataSourceProcessor.processAndCount);
 		}));
 
-		it('should make an initial request to the server for data', fakeAsync((): void => {
+		it('should make an initial request to the server for data', rlFakeAsync((): void => {
 			dataService.get = test.mock.promise([1, 2]);
 
 			let source: IAsyncDataSource<number> = new DataServiceDataSource<number>(dataService.get, dataSourceProcessor, arrayUtility);

--- a/source/components/cardContainer/dataSources/serverSideDataSource/serverSideDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/serverSideDataSource/serverSideDataSource.service.tests.ts
@@ -2,7 +2,7 @@ import { addProviders, inject } from '@angular/core/testing';
 
 import { services, filters } from 'typescript-angular-utilities';
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 import __object = services.object;
 import __array = services.array;
 
@@ -98,7 +98,7 @@ describe('ServerSideDataSource', () => {
 		expect(filters['clientSideFilter']).to.not.exist;
 	});
 
-	it('should set the data set and count with the response from the server', fakeAsync((): void => {
+	it('should set the data set and count with the response from the server', rlFakeAsync((): void => {
 		source.refresh();
 		test.mock.flushAll(dataService);
 		expect(source.dataSet[0]).to.equal(1);

--- a/source/components/cardContainer/dataSources/smartDataSource/smartDataSource.service.tests.ts
+++ b/source/components/cardContainer/dataSources/smartDataSource/smartDataSource.service.tests.ts
@@ -2,7 +2,7 @@ import { addProviders, inject } from '@angular/core/testing';
 
 import { services, filters } from 'typescript-angular-utilities';
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 import __object = services.object;
 import __array = services.array;
 
@@ -101,7 +101,7 @@ describe('SmartDataSource', () => {
 		};
 	});
 
-	it('should use the count returned by the server when a reload resolves', fakeAsync((): void => {
+	it('should use the count returned by the server when a reload resolves', rlFakeAsync((): void => {
 		let clientCount: number = 2;
 		let serverCount: number = 4;
 		dataSourceProcessor.process = sinon.spy((data: any): any => {
@@ -121,7 +121,7 @@ describe('SmartDataSource', () => {
 	}));
 
 	describe('throttled', (): void => {
-		beforeEach(fakeAsync((): void => {
+		beforeEach(rlFakeAsync((): void => {
 			data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 			dataService.get = test.mock.promise({ dataSet: data, count: 20 });
 			source.getDataSet = dataService.get;
@@ -150,7 +150,7 @@ describe('SmartDataSource', () => {
 	});
 
 	describe('not throttled', (): void => {
-		beforeEach(fakeAsync((): void => {
+		beforeEach(rlFakeAsync((): void => {
 			data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 			dataService.get = test.mock.promise({ dataSet: data, count: 10 });
 			source.getDataSet = dataService.get;

--- a/source/components/form/form.tests.ts
+++ b/source/components/form/form.tests.ts
@@ -2,7 +2,7 @@ import { FormComponent } from './form';
 import { isFunction } from 'lodash';
 import { services } from 'typescript-angular-utilities';
 import mock = services.test.mock;
-import fakeAsync = services.test.fakeAsync;
+import rlFakeAsync = services.test.rlFakeAsync;
 
 import { AsyncHelper } from '../../services/async/async.service';
 
@@ -58,7 +58,7 @@ describe('FormComponent', (): void => {
 	});
 
 	describe('saveForm', (): void => {
-		it('should mark the form as pristine after the submit completes', fakeAsync((): void => {
+		it('should mark the form as pristine after the submit completes', rlFakeAsync((): void => {
 			const saveMock = mock.promise();
 			const setPristineSpy = sinon.spy();
 			form.save = saveMock;
@@ -74,7 +74,7 @@ describe('FormComponent', (): void => {
 			sinon.assert.calledOnce(setPristineSpy);
 		}));
 
-		it('should mark the form as pristine immediately if no async action is returned', fakeAsync((): void => {
+		it('should mark the form as pristine immediately if no async action is returned', rlFakeAsync((): void => {
 			form.save = <any>(() => null);
 			const setPristineSpy = sinon.spy();
 			formService.isFormValid = <any>(() => true);

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -4,7 +4,7 @@ import { addProviders, inject } from '@angular/core/testing';
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
 import mock = __test.mock;
-import fakeAsync = __test.fakeAsync;
+import rlFakeAsync = __test.rlFakeAsync;
 import flushMicrotasks = __test.flushMicrotasks;
 
 import { ComponentValidator } from '../../../services/componentValidator/componentValidator.service';
@@ -71,7 +71,7 @@ describe('TypeaheadComponent', () => {
 			items = ['Item 1', 'Item 2', 'Another item', 'A fourth item'];
 		});
 
-		it('should return an empty list if no text is entered', fakeAsync((): void => {
+		it('should return an empty list if no text is entered', rlFakeAsync((): void => {
 			let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
 			typeahead.getItems = getItemsMock;
 
@@ -84,7 +84,7 @@ describe('TypeaheadComponent', () => {
 			getItemsMock.flush();
 		}));
 
-		it('should return the result of the getItems function if useClientSearching is off', fakeAsync((): void => {
+		it('should return the result of the getItems function if useClientSearching is off', rlFakeAsync((): void => {
 			// simulate a server-side search
 			let getItemsMock: __test.IMockedRequest<string[]> = mock.request([items[0], items[1]]);
 			typeahead.getItems = getItemsMock;
@@ -102,7 +102,7 @@ describe('TypeaheadComponent', () => {
 			expect(visibleItems[1]).to.equal(items[1]);
 		}));
 
-		it('should apply the search string if useClientSearching is on', fakeAsync((): void => {
+		it('should apply the search string if useClientSearching is on', rlFakeAsync((): void => {
 			typeahead.clientSearch = true;
 
 			let getItemsMock: __test.IMockedRequest<string[]> = mock.request(items);
@@ -122,7 +122,7 @@ describe('TypeaheadComponent', () => {
 		}));
 
 		it('should cache the results of the parent getItems function and apply searches aganst the cached data if useClientSearching is on'
-			, fakeAsync((): void => {
+			, rlFakeAsync((): void => {
 				typeahead.clientSearch = true;
 
 				let getItemsMock: __test.IMockedRequest<string> = mock.request(items);
@@ -154,7 +154,7 @@ describe('TypeaheadComponent', () => {
 	});
 
 	describe('external API', (): void => {
-		it('should add the specified item to the cached item list', fakeAsync((): void => {
+		it('should add the specified item to the cached item list', rlFakeAsync((): void => {
 			typeahead.clientSearch = true;
 
 			let items: string[] = [];
@@ -171,7 +171,7 @@ describe('TypeaheadComponent', () => {
 			expect(items[0]).to.equal(newItem);
 		}));
 
-		it('should remove the specified item from the cached items list', fakeAsync((): void => {
+		it('should remove the specified item from the cached items list', rlFakeAsync((): void => {
 			typeahead.clientSearch = true;
 
 			let items: string[] = ['Item 1'];
@@ -193,7 +193,7 @@ describe('TypeaheadComponent', () => {
 			items = ['Item 1', 'Item 2', 'Another item', 'A fourth item'];
 		});
 
-		it('should collapse if allowCollapse is turned on', fakeAsync((): void => {
+		it('should collapse if allowCollapse is turned on', rlFakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
 			typeahead.select = <any>{ emit: selectSpy };
 			typeahead.clientSearch = true;
@@ -209,7 +209,7 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.collapsed).to.be.true;
 		}));
 
-		it('should call the select function without collapsing', fakeAsync((): void => {
+		it('should call the select function without collapsing', rlFakeAsync((): void => {
 			let selectSpy: Sinon.SinonSpy = sinon.spy();
 			typeahead.clientSearch = true;
 			typeahead.select = <any>{ emit: selectSpy };
@@ -223,7 +223,7 @@ describe('TypeaheadComponent', () => {
 			sinon.assert.calledWith(selectSpy, items[0]);
 		}));
 
-		it('should call create with the search text if the search option is selected', fakeAsync((): void => {
+		it('should call create with the search text if the search option is selected', rlFakeAsync((): void => {
 			let createSpy: Sinon.SinonSpy = sinon.spy(search => { return { value: search }; });
 			typeahead.clientSearch = true;
 			typeahead.allowCollapse = true;
@@ -313,7 +313,7 @@ describe('TypeaheadComponent', () => {
 	describe('searchStream', () => {
 		let loadItems: __test.IMockedRequest<string>;
 
-		beforeEach(fakeAsync(() => {
+		beforeEach(rlFakeAsync(() => {
 			typeahead.ngOnInit();
 			const items = ['item1', 'item2', 'item3'];
 			loadItems = mock.request(items);
@@ -321,7 +321,7 @@ describe('TypeaheadComponent', () => {
 			typeahead.getItems = loadItems;
 
 			typeahead.searchStream.next('search');
-			__test.tick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
+			__test.rlTick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
 			__test.flushMicrotasks();
 			typeahead.visibleItems.subscribe(data => visibleItems = data);
 			loadItems.flush();
@@ -331,7 +331,7 @@ describe('TypeaheadComponent', () => {
 			expect(visibleItems).to.equal(items);
 		}));
 
-		it('should show a busy spinner while the debounce is pending', fakeAsync(() => {
+		it('should show a busy spinner while the debounce is pending', rlFakeAsync(() => {
 			typeahead.searchStream.next('search2');
 
 			sinon.assert.calledOnce(busy.trigger);
@@ -345,7 +345,7 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.search).to.equal('search');
 			busy.trigger.reset();
 
-			__test.tick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
+			__test.rlTick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
 			__test.flushMicrotasks();
 
 			sinon.assert.calledOnce(busy.trigger);
@@ -353,11 +353,11 @@ describe('TypeaheadComponent', () => {
 			sinon.assert.notCalled(loadItems)
 		}));
 
-		it('should make a request to refresh the visible items', fakeAsync(() => {
+		it('should make a request to refresh the visible items', rlFakeAsync(() => {
 			typeahead.searchStream.next('search2');
 
 			busy.trigger.reset();
-			__test.tick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
+			__test.rlTick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
 			__test.flushMicrotasks();
 
 			sinon.assert.calledTwice(busy.trigger);

--- a/source/components/inputs/typeaheadList/typeaheadList.tests.ts
+++ b/source/components/inputs/typeaheadList/typeaheadList.tests.ts
@@ -3,7 +3,7 @@ import { addProviders, inject } from '@angular/core/testing';
 
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
-import fakeAsync = __test.fakeAsync;
+import rlFakeAsync = __test.rlFakeAsync;
 
 import { ComponentValidator } from '../../../services/componentValidator/componentValidator.service';
 
@@ -54,7 +54,7 @@ describe('TypeaheadListComponent', () => {
 	});
 
 	describe('loadItems', (): void => {
-		it('should filter out items that are already selected', fakeAsync((): void => {
+		it('should filter out items that are already selected', rlFakeAsync((): void => {
 			const selections: ITestObject[] = [items[0], items[2]];
 			typeaheadList.value = selections;
 
@@ -68,7 +68,7 @@ describe('TypeaheadListComponent', () => {
 			getItemsMock.flush();
 		}));
 
-		it('should cache the results of the parent getItems function and apply searches aganst the cached data if useClientSearching is on', fakeAsync((): void => {
+		it('should cache the results of the parent getItems function and apply searches aganst the cached data if useClientSearching is on', rlFakeAsync((): void => {
 			getItemsMock = __test.mock.request(items);
 			typeaheadList.getItems = getItemsMock;
 			typeaheadList.searchItems('2').subscribe(() => null);
@@ -80,7 +80,7 @@ describe('TypeaheadListComponent', () => {
 			sinon.assert.notCalled(getItemsMock);
 		}));
 
-		it('should load the items when searching is disabled', fakeAsync((): void => {
+		it('should load the items when searching is disabled', rlFakeAsync((): void => {
 			getItemsMock = __test.mock.request(items);
 			typeaheadList.getItems = getItemsMock;
 			typeaheadList.ngOnChanges(<any>{
@@ -94,7 +94,7 @@ describe('TypeaheadListComponent', () => {
 			expect(typeaheadList.cachedItemsArray).to.not.be.empty;
 		}));
 
-		it('should load the items on init if searching is disabled', fakeAsync((): void => {
+		it('should load the items on init if searching is disabled', rlFakeAsync((): void => {
 			getItemsMock = __test.mock.request(items);
 			typeaheadList.getItems = getItemsMock;
 			typeaheadList.disableSearching = true;
@@ -109,7 +109,7 @@ describe('TypeaheadListComponent', () => {
 	});
 
 	describe('add', (): void => {
-		it('should remove the item from the typeahead and add it to the list', fakeAsync((): void => {
+		it('should remove the item from the typeahead and add it to the list', rlFakeAsync((): void => {
 			const list: ITestObject[] = [];
 			typeaheadList.value = list;
 			typeaheadList.searchItems('2').subscribe(() => null);
@@ -128,7 +128,7 @@ describe('TypeaheadListComponent', () => {
 			sinon.assert.calledWith(setValue, typeaheadList.value);
 		}));
 
-		it('should wait on the result if the onAdd handler returns a value', fakeAsync((): void => {
+		it('should wait on the result if the onAdd handler returns a value', rlFakeAsync((): void => {
 			const list: ITestObject[] = [];
 			typeaheadList.value = list;
 			typeaheadList.searchItems('2').subscribe(() => null);
@@ -153,7 +153,7 @@ describe('TypeaheadListComponent', () => {
 	});
 
 	describe('remove', (): void => {
-		it('should add the item back to the cached items and remove it from the list', fakeAsync((): void => {
+		it('should add the item back to the cached items and remove it from the list', rlFakeAsync((): void => {
 			const list: ITestObject[] = [items[0]];
 			typeaheadList.value = list;
 			typeaheadList.searchItems('2').subscribe(() => null);
@@ -171,7 +171,7 @@ describe('TypeaheadListComponent', () => {
 			sinon.assert.calledWith(setValue, typeaheadList.value);
 		}));
 
-		it('should wait on the result if the onRemove handler returns a value', fakeAsync((): void => {
+		it('should wait on the result if the onRemove handler returns a value', rlFakeAsync((): void => {
 			const list: ITestObject[] = [items[0]];
 			typeaheadList.value = list;
 			typeaheadList.searchItems('2').subscribe(() => null);

--- a/source/components/messageLog/messageLog.service.tests.ts
+++ b/source/components/messageLog/messageLog.service.tests.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { services } from 'typescript-angular-utilities';
 import __array = services.array;
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 
 import {
 	moduleName,
@@ -58,7 +58,7 @@ describe('messageLog', () => {
 			, '16', '17', '18', '19', '20'];
 	}
 
-	it('should load an initial page of messages from the server', fakeAsync((): void => {
+	it('should load an initial page of messages from the server', rlFakeAsync((): void => {
 		messageLog.dataService = <any>dataService;
 
 		sinon.assert.calledOnce(dataService.getMessages);
@@ -68,13 +68,13 @@ describe('messageLog', () => {
 	}));
 
 	describe('after initial request', (): void => {
-		beforeEach(fakeAsync((): void => {
+		beforeEach(rlFakeAsync((): void => {
 			messageLog.dataService = <any>dataService;
 			test.mock.flushAll(dataService);
 			dataService.getMessages.reset();
 		}));
 
-		it('should load the next page from the server if more messages are available', fakeAsync((): void => {
+		it('should load the next page from the server if more messages are available', rlFakeAsync((): void => {
 			messageLog.getNextPage();
 			sinon.assert.calledOnce(dataService.getMessages);
 			test.mock.flushAll(dataService);
@@ -86,7 +86,7 @@ describe('messageLog', () => {
 			expect(messageLog.visibleMessages[4]).to.equal('10');
 		}));
 
-		it('should not load a full page if not enough messages are available', fakeAsync((): void => {
+		it('should not load a full page if not enough messages are available', rlFakeAsync((): void => {
 			messageLog.pageSize = 15;
 			test.mock.flushAll(dataService);
 
@@ -104,7 +104,7 @@ describe('messageLog', () => {
 			expect(messageLog.visibleMessages[4]).to.equal('20');
 		}));
 
-		it('should refresh the current page when the page size changes', fakeAsync((): void => {
+		it('should refresh the current page when the page size changes', rlFakeAsync((): void => {
 			messageLog.pageSize = 10;
 			sinon.assert.calledOnce(dataService.getMessages);
 			test.mock.flushAll(dataService);
@@ -113,7 +113,7 @@ describe('messageLog', () => {
 		}));
 
 		it('should load a full page when paging back to the beginning even if less than a full page of messages were paged back'
-			, fakeAsync((): void => {
+			, rlFakeAsync((): void => {
 				messageLog.getNextPage();
 				(<any>dataService.getMessages).flush();
 
@@ -140,7 +140,7 @@ describe('messageLog', () => {
 				expect(messageLog.visibleMessages[9]).to.equal('10');
 			}));
 
-		it('should disable paging forward if no more messages are available', fakeAsync((): void => {
+		it('should disable paging forward if no more messages are available', rlFakeAsync((): void => {
 			messageLog.pageSize = 20;
 			test.mock.flushAll(dataService);
 			dataService.getMessages.reset();
@@ -160,7 +160,7 @@ describe('messageLog', () => {
 			expect(messageLog.hasBackwardMessages).to.be.false;
 		});
 
-		it('should load first page when getTopPage is called', fakeAsync((): void => {
+		it('should load first page when getTopPage is called', rlFakeAsync((): void => {
 			messageLog.getNextPage();
 			messageLog.getNextPage();
 			sinon.assert.calledTwice(dataService.getMessages);
@@ -185,7 +185,7 @@ describe('messageLog', () => {
 			expect(messageLog.visibleMessages[4]).to.equal('5');
 		}));
 
-		it('should save a new message, add it to the beginning of the log, and display it if on the first page', fakeAsync((): void => {
+		it('should save a new message, add it to the beginning of the log, and display it if on the first page', rlFakeAsync((): void => {
 			messageLog.addMessage(<any>'new message');
 			sinon.assert.calledOnce(dataService.saveMessage);
 			// save request
@@ -196,7 +196,7 @@ describe('messageLog', () => {
 			expect(messageLog.visibleMessages[0]).to.equal('new message');
 		}));
 
-		it('should delete the message and refresh the current page', fakeAsync((): void => {
+		it('should delete the message and refresh the current page', rlFakeAsync((): void => {
 			messageLog.getNextPage();
 			test.mock.flushAll(dataService);
 
@@ -219,7 +219,7 @@ describe('messageLog', () => {
 			expect(messageLog.visibleMessages[4]).to.equal('11');
 		}));
 
-		it('should take the user back to the first page if the user adds a new message', fakeAsync((): void => {
+		it('should take the user back to the first page if the user adds a new message', rlFakeAsync((): void => {
 			messageLog.getNextPage();
 			test.mock.flushAll(dataService);
 			dataService.getMessages.reset();

--- a/source/components/multiStepIndicator/multiStepIndicator.tests.ts
+++ b/source/components/multiStepIndicator/multiStepIndicator.tests.ts
@@ -3,7 +3,7 @@ import * as ui from 'angular-ui-router';
 import { services } from 'typescript-angular-utilities';
 import __test = services.test;
 import mock = __test.mock;
-import fakeAsync = __test.fakeAsync;
+import rlFakeAsync = __test.rlFakeAsync;
 import IMockedPromise = __test.IMockedPromise;
 
 import { MultiStepIndicatorComponent, IStep, IConfiguredStep } from './multiStepIndicator';
@@ -39,7 +39,7 @@ describe('MultiStepIndicatorComponent', () => {
         expect((<IConfiguredStep>step).isActive).to.be.true;
     });
 
-    it('should provide a default click handler that redirects to the specified state and sets the step to current if a state name is provided', fakeAsync((): void => {
+    it('should provide a default click handler that redirects to the specified state and sets the step to current if a state name is provided', rlFakeAsync((): void => {
         let step: IStep = <any>{ stateName: 'state' };
 
         msi.steps = <IConfiguredStep[]>[step];
@@ -68,7 +68,7 @@ describe('MultiStepIndicatorComponent', () => {
         expect(step2.isCurrent).to.be.false;
     });
 
-    it('should show a spinner on the step and disable all clicks when the step is loading', fakeAsync((): void => {
+    it('should show a spinner on the step and disable all clicks when the step is loading', rlFakeAsync((): void => {
         let step1: IStep = <any>{ onClick: mock.promise() };
         let step2: IStep = <any>{ onClick: sinon.spy() };
 
@@ -87,7 +87,7 @@ describe('MultiStepIndicatorComponent', () => {
         sinon.assert.notCalled(<Sinon.SinonSpy>step2.onClick);
     }));
 
-    it('should clear the spinner when the promise resolves', fakeAsync((): void => {
+    it('should clear the spinner when the promise resolves', rlFakeAsync((): void => {
         let step: IStep = <any>{ onClick: mock.promise() };
 
         msi.steps = <IConfiguredStep[]>[step];
@@ -103,7 +103,7 @@ describe('MultiStepIndicatorComponent', () => {
         expect((<IConfiguredStep>step).isLoading).to.be.false;
     }));
 
-    it('should clear the spinner when the promise rejects', fakeAsync((): void => {
+    it('should clear the spinner when the promise rejects', rlFakeAsync((): void => {
         const fakeError = 'fakeError';
         let step: IStep = <any>{ onClick: mock.rejectedPromise(fakeError) };
 

--- a/source/services/async/async.service.tests.ts
+++ b/source/services/async/async.service.tests.ts
@@ -3,7 +3,7 @@ import { Subject } from 'rxjs';
 import { services } from 'typescript-angular-utilities';
 import IMockedPromise = services.test.IMockedPromise;
 import mock = services.test.mock;
-import fakeAsync = services.test.fakeAsync;
+import rlFakeAsync = services.test.rlFakeAsync;
 
 import { AsyncHelper } from './async.service';
 
@@ -14,7 +14,7 @@ describe('AsyncHelper', () => {
 		async = new AsyncHelper();
 	});
 
-	it('should fire immediately after the action completes on a primitive', fakeAsync((): void => {
+	it('should fire immediately after the action completes on a primitive', rlFakeAsync((): void => {
 		let nullValue;
 		let falseValue;
 		let trueValue;

--- a/source/services/autosave/triggers/onChangeTrigger.tests.ts
+++ b/source/services/autosave/triggers/onChangeTrigger.tests.ts
@@ -54,7 +54,7 @@ describe('onChangeTrigger', () => {
 		trigger = new OnChangeTrigger($rootScope);
 	});
 
-	it('should trigger autosave when the form becomes dirty and valid after the debounce duration', test.fakeAsync((): void => {
+	it('should trigger autosave when the form becomes dirty and valid after the debounce duration', test.rlFakeAsync((): void => {
 		trigger.configure({
 			form: <any>baseContentForm,
 			debounceDuration: 1000,
@@ -67,13 +67,13 @@ describe('onChangeTrigger', () => {
 
 		$rootScope.$digest();
 
-		test.tick(1000);
+		test.rlTick(1000);
 		test.flushMicrotasks();
 
 		sinon.assert.calledOnce(saveSpy);
 	}));
 
-	it('should not save if the form is dirty but invalid', test.fakeAsync((): void => {
+	it('should not save if the form is dirty but invalid', test.rlFakeAsync((): void => {
 		trigger.configure({
 			form: <any>baseContentForm,
 			debounceDuration: 1000,
@@ -85,13 +85,13 @@ describe('onChangeTrigger', () => {
 
 		$rootScope.$digest();
 
-		test.tick(1000);
+		test.rlTick(1000);
 		test.flushMicrotasks();
 
 		sinon.assert.notCalled(saveSpy);
 	}));
 
-	it('should not save if the form is valid but not dirty', test.fakeAsync((): void => {
+	it('should not save if the form is valid but not dirty', test.rlFakeAsync((): void => {
 		trigger.configure({
 			form: <any>baseContentForm,
 			debounceDuration: 1000,
@@ -103,13 +103,13 @@ describe('onChangeTrigger', () => {
 
 		$rootScope.$digest();
 
-		test.tick(1000);
+		test.rlTick(1000);
 		test.flushMicrotasks();
 
 		sinon.assert.notCalled(saveSpy);
 	}));
 
-	it('should not save if the form is dirty and invalid if saveWhenInvalid was specified', test.fakeAsync((): void => {
+	it('should not save if the form is dirty and invalid if saveWhenInvalid was specified', test.rlFakeAsync((): void => {
 		trigger.configure({
 			form: <any>baseContentForm,
 			debounceDuration: 1000,
@@ -122,13 +122,13 @@ describe('onChangeTrigger', () => {
 
 		$rootScope.$digest();
 
-		test.tick(1000);
+		test.rlTick(1000);
 		test.flushMicrotasks();
 
 		sinon.assert.calledOnce(saveSpy);
 	}));
 
-	it('should reset the debounce timer on form changes', test.fakeAsync((): void => {
+	it('should reset the debounce timer on form changes', test.rlFakeAsync((): void => {
 		let triggerChange: { (): void };
 		let changeListener: any = (callback: { (): void }): Sinon.SinonSpy => {
 			triggerChange = callback;
@@ -147,17 +147,17 @@ describe('onChangeTrigger', () => {
 
 		$rootScope.$digest();
 
-		test.tick(500);
+		test.rlTick(500);
 		test.flushMicrotasks();
 
 		triggerChange();
 
-		test.tick(500);
+		test.rlTick(500);
 		test.flushMicrotasks();
 
 		sinon.assert.notCalled(saveSpy);
 
-		test.tick(500);
+		test.rlTick(500);
 		test.flushMicrotasks();
 
 		sinon.assert.calledOnce(saveSpy);

--- a/source/services/autosaveAction/autosaveAction.service.tests.ts
+++ b/source/services/autosaveAction/autosaveAction.service.tests.ts
@@ -21,18 +21,18 @@ describe('AutosaveActionService', () => {
 		expect(autosaveAction.saving).to.be.true;
 	});
 
-	it('should set successful to true if the request resolves successfully', __test.fakeAsync((): void => {
+	it('should set successful to true if the request resolves successfully', __test.rlFakeAsync((): void => {
 		mockAction.flush();
 
 		expect(autosaveAction.saving).to.be.false;
 		expect(autosaveAction.complete).to.be.true;
 		expect(autosaveAction.successful).to.be.true;
 
-		__test.tick(COMPLETE_MESSAGE_DURATION);
+		__test.rlTick(COMPLETE_MESSAGE_DURATION);
 		__test.flushMicrotasks();
 	}));
 
-	it('should set successful to false if the promise fails', __test.fakeAsync((): void => {
+	it('should set successful to false if the promise fails', __test.rlFakeAsync((): void => {
 		mockAction = __test.mock.rejectedRequest();
 		autosaveAction.trigger(mockAction());
 		mockAction.flush();
@@ -41,16 +41,16 @@ describe('AutosaveActionService', () => {
 		expect(autosaveAction.complete).to.be.true;
 		expect(autosaveAction.successful).to.be.false;
 
-		__test.tick(COMPLETE_MESSAGE_DURATION);
+		__test.rlTick(COMPLETE_MESSAGE_DURATION);
 		__test.flushMicrotasks();
 	}));
 
-	it('should set complete to false after the duration', __test.fakeAsync((): void => {
+	it('should set complete to false after the duration', __test.rlFakeAsync((): void => {
 		mockAction.flush();
 
 		expect(autosaveAction.complete).to.be.true;
 
-		__test.tick(COMPLETE_MESSAGE_DURATION);
+		__test.rlTick(COMPLETE_MESSAGE_DURATION);
 		__test.flushMicrotasks();
 
 		expect(autosaveAction.complete).to.be.false;

--- a/source/services/dialog/bootstrapModalDialog/bootstrapModalDialog.service.tests.ts
+++ b/source/services/dialog/bootstrapModalDialog/bootstrapModalDialog.service.tests.ts
@@ -1,6 +1,6 @@
 import { services } from 'typescript-angular-utilities';
 import test = services.test;
-import fakeAsync = test.fakeAsync;
+import rlFakeAsync = test.rlFakeAsync;
 
 import { moduleName, serviceName, BootstrapModalDialogService } from './bootstrapModalDialog.module';
 import { IDialogInstance } from '../dialog.service.ng1';
@@ -71,7 +71,7 @@ describe('bootstrapModalDialog', () => {
 		sinon.assert.calledOnce(event.preventDefault);
 	});
 
-	it('should resolve promises and provide the results as locals on the dialog controller', fakeAsync(() => {
+	it('should resolve promises and provide the results as locals on the dialog controller', rlFakeAsync(() => {
 		let data: any = { prop: 5 };
 		let dataService: any = {
 			get: test.mock.promise(data),
@@ -105,7 +105,7 @@ describe('bootstrapModalDialog', () => {
 		expect(dataResult).to.equal(data);
 	}));
 
-	it('should not open the dialog if resolve fails', fakeAsync(() => {
+	it('should not open the dialog if resolve fails', rlFakeAsync(() => {
 		let dataService: any = {
 			get: test.mock.rejectedPromise(new Error()),
 		};
@@ -123,7 +123,7 @@ describe('bootstrapModalDialog', () => {
 		sinon.assert.notCalled($uibModal.open);
 	}));
 
-	it('should return an object with functions to dismiss and close the dialog once its open', fakeAsync((): void => {
+	it('should return an object with functions to dismiss and close the dialog once its open', rlFakeAsync((): void => {
 		const options: any = {
 			resolve: {
 				data: test.mock.promise<void>(),


### PR DESCRIPTION
This is one area where my test coverage fell short the first time around, because I didn't know how to test these rxjs operators. Now that rxjs scheduling is possible, added test coverage for the search stream behavior. Essentially there are two main cases:
1) User changes the search, gets the debounce spinner, but then changes it back before the search fires. The spinner will then hide and the `distinctUntilChanged()` operator will suppress the event.
2) User changes the search and the debounce elapses. The typeahead then fires off a reload request and triggers the spinner on the request.

Needs https://github.com/RenovoSolutions/TypeScript-Angular-Utilities/pull/161
