### PR TITLE
rlAsync stops displaying loading when stream complete

### DIFF
--- a/source/components/busy/busy.tests.ts
+++ b/source/components/busy/busy.tests.ts
@@ -42,8 +42,14 @@ describe('busy', () => {
 			expect(busy.loading).to.be.true;
 		});
 
-		it('should finish after an event is received', (): void => {
+		it('should not finish after an event is received', (): void => {
 			stream.next(null);
+
+			expect(busy.loading).to.be.true;
+		});
+
+		it('should finish after an event is complete', (): void => {
+			stream.complete();
 
 			expect(busy.loading).to.be.false;
 		});

--- a/source/components/busy/busy.ts
+++ b/source/components/busy/busy.ts
@@ -18,7 +18,7 @@ export class BusyComponent {
 	asyncHelper: AsyncHelper;
 
 	constructor(defaultTheme: DefaultTheme
-			, asyncHelper: AsyncHelper) {
+		, asyncHelper: AsyncHelper) {
 		this.useDefaultTheme = defaultTheme.useDefaultTheme;
 		this.asyncHelper = asyncHelper;
 	}
@@ -38,6 +38,6 @@ export class BusyComponent {
 
 		this.loading = true;
 		this.asyncHelper.waitAsObservable(waitOn)
-			.subscribe(() => this.loading = false);
+			.subscribe(null, null, () => this.loading = false);
 	}
 }


### PR DESCRIPTION
For streams with more than one event, rlAsync was incorrectly showing loading as done after the first event. by switching it to only set loading to false when complete, the loading symbol is removed at the end of the event stream.

paired with @arknotts 
