### PR TITLE
Add FocusOn directive and add to card container

### DIFF
--- a/source/behaviors/behaviors.module.ts
+++ b/source/behaviors/behaviors.module.ts
@@ -6,8 +6,9 @@ import * as autosave from './autosave/autosave.ng1';
 import * as offClick from './offClick/offClick.ng1';
 import * as popover from './popover/popover';
 import * as required from './required/required';
+import * as focusOn from './focusOn/focusOn.ng1';
 
-export { alias, autosave, offClick, popover, required };
+export { alias, autosave, offClick, popover, required, focusOn };
 
 export var moduleName: string = 'rl.ui.behaviors';
 
@@ -18,4 +19,5 @@ angular.module(moduleName, [
 	offClick.moduleName,
 	popover.moduleName,
 	required.moduleName,
+	focusOn.moduleName
 ]);

--- a/source/behaviors/focusOn/focusOn.ng1.ts
+++ b/source/behaviors/focusOn/focusOn.ng1.ts
@@ -1,0 +1,29 @@
+import * as angular from 'angular';
+
+export const moduleName: string = 'rl.ui.behaviors.focusOn';
+export const directiveName: string = 'rlFocusOn';
+
+export function focusOn($timeout, $parse): angular.IDirective {
+	return {
+		link: function(scope, element, attrs: any) {
+			var model = $parse(attrs.rlFocusOn);
+			scope.$watch(model, function (value) {
+				if (value === true) {
+					$timeout(function () {
+						let thisElement = element[0];
+						if (thisElement.tagName.toLowerCase() == 'input') {
+							thisElement.focus();
+						}
+						else {
+							let ngElement = angular.element(thisElement);
+							ngElement.find('input').focus();
+						}
+					});
+				}
+			});
+		}
+	};
+}
+
+angular.module(moduleName, [])
+	.directive(directiveName, focusOn);

--- a/source/components/cardContainer/cardContainer.ng1.ts
+++ b/source/components/cardContainer/cardContainer.ng1.ts
@@ -105,6 +105,7 @@ export class CardContainerController {
 	saveWhenInvalid: boolean;
 	selectionChangedEvent: { (): void };
 	searchPlaceholder: string;
+	focusSearchOn: boolean;
 
 	dataSource: IDataSource<any>;
 	sortDirection: ISortDirections;
@@ -382,6 +383,7 @@ export let cardContainer: angular.IComponentOptions = {
 		cardControllerAs: '@',
 		cardAs: '@',
 		selectionChangedEvent: '&selectionChanged',
-		searchPlaceholder: '<'
+		searchPlaceholder: '<',
+		focusSearchOn: '<'
 	}
 }

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ng1.html
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ng1.html
@@ -1,6 +1,6 @@
 <div class="input-group" ng-show="cardSearch.hasSearchFilter" ng-class="{ 'has-error': cardSearch.searchLengthError }">
 	<input class="form-control" type="text" placeholder="{{cardSearch.searchPlaceholder}}" ng-model="cardSearch.searchText"
-		   rl-popover="cardSearch.minSearchError" popover-trigger="mouseenter" popover-enable="cardSearch.searchLengthError" />
+		   rl-popover="cardSearch.minSearchError" popover-trigger="mouseenter" popover-enable="cardSearch.searchLengthError" rl-focus-on="cardSearch.focusOn" />
 	<div class="input-group-btn">
 		<button type="button" class="btn btn-default" ng-disabled="cardSearch.searchText | isEmpty" ng-click="cardSearch.searchText = null">
 			<i class="fa fa-times"></i>

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ng1.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ng1.ts
@@ -53,6 +53,10 @@ export class CardSearchController {
 	static $inject: string[] = ['$timeout'];
 	constructor(private $timeout: angular.ITimeoutService) {}
 
+	get focusOn(): boolean {
+		return this.cardContainer.focusSearchOn;
+	}
+
 	$onInit(): void {
 		if (this.cardContainer == null) {
 			return;


### PR DESCRIPTION
This adds an rl-focus-on directive to angular 1 and consumes it in the ng1 card container. This directive will conditionally focus an input field based on the passed in condition. If this is added directly to an input control, the input control will be focused. If not, it will search for an input control within the child controls to focus. No ng2 version was implemented because ideally ng1 will go away in the near future and in ng2 it's easier to target elements for focus without a separate directive. 

Resolves https://renovo.myjetbrains.com/youtrack/issue/MUSIC-933
