### PR TITLE
Updating the MSI to use the newer style, for both ng1 and ng2.

### DIFF
--- a/source/components/multiStepIndicator/multiStepIndicator.html
+++ b/source/components/multiStepIndicator/multiStepIndicator.html
@@ -1,17 +1,17 @@
-<div class="multi-step"
+<div class="rl-multi-step"
 	[class.numbered]="numbered"
 	[class.checked]="checked">
-	<ol>
-		<li *ngFor="let step of steps" (click)="onClick(step)"
+	<ol class="rl-multi-step-list">
+		<li class="rl-multi-step-item" *ngFor="let step of steps" (click)="onClick(step)"
 			[class.completed]="step.getCompleted()"
 			[class.current]="step.isCurrent"
-			[class.active]="step.isActive && !anyLoading()">
-			<div class="wrap"
-				 [class.multi-step-loading]="step.isLoading">
+			[class.active]="step.isActive && !anyLoading()"
+			[class.error]="!step.getValid()"
+			[class.rl-multi-step-loading]="step.isLoading">
+			<div class="rl-item-wrap">
 				<p class="badge" *ngIf="step.count">{{step.count()}}</p>
-				<p class="error" *ngIf="!step.getValid()"></p>
-				<p class="title">{{step.title}} <rlBusy [loading]="step.isLoading"></rlBusy></p>
-				<p class="subtitle">{{step.subtitle}}</p>
+				<p class="rl-item-title">{{step.title}} <rlBusy [loading]="step.isLoading"></rlBusy></p>
+				<p class="rl-item-subtitle">{{step.subtitle}}</p>
 			</div>
 		</li>
 	</ol>

--- a/source/components/multiStepIndicator/multiStepIndicator.ng1.html
+++ b/source/components/multiStepIndicator/multiStepIndicator.ng1.html
@@ -1,13 +1,15 @@
-<div class="multi-step" ng-class="{ 'numbered': breadcrumb.numbered, 'checked': breadcrumb.checked }">
-	<ol>
-		<li ng-repeat="step in breadcrumb.steps" ng-click="breadcrumb.onClick(step)"
-			ng-class="{ 'completed': step.getCompleted(), 'current': step.isCurrent, 'active': !step.inactive && !breadcrumb.anyLoading() }">
-			<div class="wrap"
-				 ng-class="{ 'multi-step-loading': step.loading }">
+<div class="rl-multi-step" ng-class="{ 'numbered': breadcrumb.numbered, 'checked': breadcrumb.checked }">
+	<ol class="rl-multi-step-list">
+		<li class="rl-multi-step-item" ng-repeat="step in breadcrumb.steps" ng-click="breadcrumb.onClick(step)"
+			ng-class="{ 'completed': step.getCompleted(),
+						'current': step.isCurrent,
+						'active': !step.inactive && !breadcrumb.anyLoading(),
+						'error': !step.getValid(),
+						'rl-multi-step-loading': step.loading }">
+			<div class="rl-item-wrap">
 				<p class="badge" ng-show="step.hasCount">{{step.count()}}</p>
-				<p class="error" ng-if="!step.getValid()"></p>
-				<p class="title">{{step.title}} <rl-busy loading="step.loading"></rl-busy></p>
-				<p class="subtitle">{{step.subtitle}}</p>
+				<p class="rl-item-title">{{step.title}} <rl-busy loading="step.loading"></rl-busy></p>
+				<p class="rl-item-subtitle">{{step.subtitle}}</p>
 			</div>
 		</li>
 	</ol>


### PR DESCRIPTION
**Youtrack Issue: https://renovo.myjetbrains.com/youtrack/issue/THM-60**
- Added 'rl' prefixed classes to each piece of the MSI. Easier to change this way.
- Moved the error class from it's own element to being applied on the step item itself.

**Requires Theme changes to display properly, otherwise it will just show up as a list.**
**Theme PR: https://github.com/RenovoSolutions/RenovoTheme/pull/231**
### Old

![image](https://cloud.githubusercontent.com/assets/13574057/17784533/de8c96c0-654a-11e6-93bb-674d8fc6a4f5.png)
### New

![new-msi](https://cloud.githubusercontent.com/assets/13574057/17784513/c30a81dc-654a-11e6-94fc-3be318a44250.gif)
