### PR TITLE
Fix for busy if an error is thrown

### DIFF
--- a/source/components/busy/busy.tests.ts
+++ b/source/components/busy/busy.tests.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 
 import { services } from 'typescript-angular-utilities';
 import IMockedPromise = services.test.IMockedPromise;
@@ -50,6 +50,12 @@ describe('busy', () => {
 
 		it('should finish after an event is complete', (): void => {
 			stream.complete();
+
+			expect(busy.loading).to.be.false;
+		});
+
+		it('should finish after an event errors', (): void => {
+			stream.error(new Error('Error'));
 
 			expect(busy.loading).to.be.false;
 		});

--- a/source/components/busy/busy.ts
+++ b/source/components/busy/busy.ts
@@ -38,6 +38,6 @@ export class BusyComponent {
 
 		this.loading = true;
 		this.asyncHelper.waitAsObservable(waitOn)
-			.subscribe(null, null, () => this.loading = false);
+			.subscribe(null, () => this.loading = false, () => this.loading = false);
 	}
 }


### PR DESCRIPTION
currently if an error is thrown then the busy image will continue on until the page is refreshed wich is especially problematic on async buttons.
