### PR TITLE
Add $inject to focusOn for strict mode in RL21.

### DIFF
--- a/source/behaviors/focusOn/focusOn.ng1.ts
+++ b/source/behaviors/focusOn/focusOn.ng1.ts
@@ -3,6 +3,7 @@ import * as angular from 'angular';
 export const moduleName: string = 'rl.ui.behaviors.focusOn';
 export const directiveName: string = 'rlFocusOn';
 
+focusOn.$inject = ['$timeout', '$parse'];
 export function focusOn($timeout, $parse): angular.IDirective {
 	return {
 		link: function(scope, element, attrs: any) {


### PR DESCRIPTION
The bootstrapper was OK without it, but RL21 needs it so the files can be minified and bundled.

Relates to https://renovo.myjetbrains.com/youtrack/issue/MUSIC-933
