### PR TITLE
Add card container w/ filters example to bootstrapper

### DIFF
--- a/bootstrapper/cards/cardsNg2.html
+++ b/bootstrapper/cards/cardsNg2.html
@@ -66,11 +66,22 @@
 				  useDateRange="true"
 				  useTime="true"></rlDateFilter>
 </div>
-<div>
-	<rlFilterGroup [filterGroup]="filterGroup"></rlFilterGroup>
-	<rlFilterGroup [filterGroup]="modeFilterGroup"></rlFilterGroup>
-	<rlFilterGroup [filterGroup]="rangeFilterGroup"></rlFilterGroup>
-	<rlFilterGroup [filterGroup]="disabledFilterGroup" [disabled]="true"></rlFilterGroup>
+<div class="row">
+	<div class="col-sm-2">
+		<rlFilterGroup [filterGroup]="modeFilterGroup" [dataSource]="builderWithFilters._dataSource"></rlFilterGroup>
+		<rlFilterGroup [filterGroup]="rangeFilterGroup" [dataSource]="builderWithFilters._dataSource"></rlFilterGroup>
+		<rlFilterGroup [filterGroup]="disabledFilterGroup" [dataSource]="builderWithFilters._dataSource" [disabled]="true"></rlFilterGroup>
+	</div>
+	<div class="col-sm-10">
+		<label>Card Container with Filters:</label>
+		<rlCardContainer [builder]="builderWithFilters">
+			<div *rlColumnContent="let value; name 'value'">#{{value}}</div>
+			<div *rlCardContent="let myItem">
+				Name: {{myItem.name}}
+				Value: {{myItem.value}}
+			</div>
+		</rlCardContainer>
+	</div>
 </div>
 <div>
 	<rlSelectFilter [filter]="selectFilter"

--- a/bootstrapper/cards/cardsNg2Bootstrapper.ts
+++ b/bootstrapper/cards/cardsNg2Bootstrapper.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { mapValues, map, range } from 'lodash';
 import { BehaviorSubject, Observable } from 'rxjs';
+import * as _ from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __date = services.date;
@@ -14,9 +15,9 @@ import { INPUT_DIRECTIVES } from '../../source/components/inputs/index';
 import { CARD_CONTAINER_DIRECTIVES } from '../../source/components/cardContainer/index';
 import {
 	DateFilter,
-	FilterGroup,
-	ModeFilterGroup,
-	RangeFilterGroup,
+	IFilterGroup,
+	IModeFilterGroup,
+	IRangeFilterGroup,
 	SelectFilter,
 } from '../../source/components/cardContainer/filters/index';
 
@@ -24,6 +25,15 @@ interface ICardItem {
 	name: string;
 	value: number;
 }
+
+const rangeLow: number = 1;
+const rangeHigh: number = 101;
+const items: ICardItem[] = map(range(rangeLow, rangeHigh), (num: number): ICardItem => {
+	return {
+		name: 'Item' + num,
+		value: num,
+	};
+});
 
 @Component({
 	selector: 'tsCardsBootstrapper',
@@ -38,29 +48,23 @@ interface ICardItem {
 export class CardsBootstrapper {
 	alwaysOpen: boolean = false;
 	builder: builder.CardContainerBuilder;
+	builderWithFilters: builder.CardContainerBuilder;
 	options: number[];
 	dateFilter: DateFilter;
-	filterGroup: FilterGroup;
-	modeFilterGroup: ModeFilterGroup;
-	rangeFilterGroup: RangeFilterGroup;
-	disabledFilterGroup: FilterGroup;
+	modeFilterGroup: IModeFilterGroup;
+	rangeFilterGroup: IRangeFilterGroup;
+	disabledFilterGroup: IFilterGroup;
 	selectFilter: SelectFilter<any, any>;
 
 	constructor(timezone: __timezone.TimezoneService
 			, cardContainerBuilder: builder.CardContainerBuilder) {
 		timezone.setCurrentTimezone('-05:00');
 
-		const items: ICardItem[] = map(range(1, 101), (num: number): ICardItem => {
-			const value = Math.floor(Math.random() * 2) + 1;
-			return {
-				name: 'Item' + num,
-				value: value,
-			};
-		});
-
 		this.options = [1, 2, 3, 4, 5];
 
 		this.builder = cardContainerBuilder;
+		this.builderWithFilters = _.cloneDeep(cardContainerBuilder);
+
 		this.builder.dataSource.buildDataServiceDataSource<ICardItem>(() => Observable.of(items).delay(1000));
 		this.builder.usePaging();
 		this.builder.addColumn({
@@ -78,49 +82,48 @@ export class CardsBootstrapper {
 		});
 		this.builder.useSearch();
 
+		this.initFilteredCardContainer();
+
 		this.dateFilter = new DateFilter({
 			type: 'dateFilter',
 			valueSelector: 'date',
 		}, __date.dateUtility, __transform.transform);
 
-		this.filterGroup = new FilterGroup({
-			type: 'testGroup',
-			label: 'Filter Group',
-			options: [
-				{
-					label: 'Show',
-					filter: item => item.show,
-					serialize: () => 'show',
-				},
-				{
-					label: 'Hide',
-					filter: item => !item.show,
-					serialize: () => 'hide',
-				},
-			],
-		}, __object.objectUtility);
-
-		this.modeFilterGroup = new ModeFilterGroup({
-			type: 'testModeGroup',
-			label: 'Mode Filter Group',
-			getValue: 'value',
-			options: [
-				{
-					label: 'All',
-					displayAll: true,
-				},
-				{
-					label: 'Value 1',
-					value: 1,
-				},
-			],
+		this.selectFilter = new SelectFilter({
+			valueSelector: 'value',
 		}, __object.objectUtility, __transform.transform);
 
-		this.rangeFilterGroup = new RangeFilterGroup({
+		this.dateFilter.subscribe(value => console.log(mapValues(value, date => date != null ? date.format(__date.defaultFormats.dateTimeFormat) : null)));
+		this.selectFilter.subscribe(value => console.log(value));
+	}
+
+	initFilteredCardContainer() {
+		this.builderWithFilters.dataSource.buildDataServiceDataSource<ICardItem>(() => Observable.of(items).delay(1000));
+		this.builderWithFilters.usePaging();
+		this.builderWithFilters.addColumn({
+			name: 'name',
+			label: 'Name',
+			size: 6,
+			getValue: 'name',
+		});
+		this.builderWithFilters.addColumn({
+			name: 'value',
+			label: 'Value',
+			size: 6,
+			getValue: 'value',
+			template: '<b>{{myItem.value}}</b>',
+		});
+
+		this.rangeFilterGroup = this.builderWithFilters.filters.buildRangeFilterGroup({
 			type: 'testRangeGroup',
 			label: 'Range Filter Group',
 			getValue: 'value',
 			options: [
+				{
+					label: 'All',
+					highInclusive: rangeHigh,
+					lowInclusive: 0
+				},
 				{
 					label: '5 - 10',
 					highInclusive: 10,
@@ -131,35 +134,48 @@ export class CardsBootstrapper {
 					highExclusive: 5,
 				},
 			],
-		}, __object.objectUtility, __transform.transform);
+		});
 
-		this.disabledFilterGroup = new FilterGroup({
+		this.modeFilterGroup = this.builderWithFilters.filters.buildModeFilterGroup({
+			type: 'testModeGroup',
+			label: 'Mode Filter Group',
+			getValue: 'value',
+			options: [
+				{
+					label: 'All',
+					displayAll: true,
+				},
+				{
+					label: 'Value Equals 3',
+					value: 3,
+				},
+				{
+					label: 'Value Equals 10',
+					value: 10,
+				},
+			],
+		});
+
+		this.disabledFilterGroup = this.builderWithFilters.filters.buildFilterGroup({
 			type: 'testGroup',
 			label: 'Disabled Filter Group',
 			options: [
 				{
 					label: 'Show',
-					filter: item => item.show,
+					filter: item => true,
 					serialize: () => 'show',
 				},
 				{
 					label: 'Hide',
-					filter: item => !item.show,
+					filter: item => false,
 					serialize: () => 'hide',
 				},
 			],
-		}, __object.objectUtility);
+		});
 
-		this.selectFilter = new SelectFilter({
-			valueSelector: 'value',
-		}, __object.objectUtility, __transform.transform);
-
-		this.dateFilter.subscribe(value => console.log(mapValues(value, date => date != null ? date.format(__date.defaultFormats.dateTimeFormat) : null)));
-		this.filterGroup.subscribe(value => console.log(value));
-		this.modeFilterGroup.subscribe(value => console.log(value));
-		this.rangeFilterGroup.subscribe(value => console.log(value));
-		this.disabledFilterGroup.subscribe(value => console.log(value));
-		this.selectFilter.subscribe(value => console.log(value));
+		this.modeFilterGroup.subscribe(value => console.log('mode filter change', value));
+		this.rangeFilterGroup.subscribe(value => console.log('range filter change', value));
+		this.disabledFilterGroup.subscribe(value => console.log('disabled filter change', value));
 	}
 
 	submitAsync: { (data: any): Promise<void> } = (data: any) => {


### PR DESCRIPTION
The filters were just in there as an example, not hooked up to a card container. This PR creates a card container and hooks them up so they will filter the data within.

Relates to https://renovo.myjetbrains.com/youtrack/issue/MUSIC-908, but doesn't contain any code right now that resolves it. This was more to make it testable in the bootstrapper. 
