### PR TITLE
Moving the styling that was attached to `.show-date-picker` to a new …

### DIFF
--- a/source/components/inputs/dateTime/dateTime.html
+++ b/source/components/inputs/dateTime/dateTime.html
@@ -2,7 +2,7 @@
 	 [class.has-warning]="!validFormat"
 	 [class.error]="!control.valid"
 	 [class.datepicker-with-clear]="showClear">
-	<span #datepicker class="show-date-picker">
+	<span #datepicker class="datepicker-input-group">
 		<label class="label-slide angular-animate" [hidden]="!(value && label)">{{label}}</label>
 		<input type="text"
 			   #dateinput

--- a/source/components/inputs/dateTime/dateTime.ng1.html
+++ b/source/components/inputs/dateTime/dateTime.ng1.html
@@ -1,5 +1,5 @@
 <div class="field date-time" ng-class="{ 'has-warning': !dateTime.validFormat, 'error': dateTime.ngModel.$invalid, 'datepicker-with-clear': dateTime.clearButton }">
-	<span class="show-date-picker">
+	<span class="show-date-picker datepicker-input-group">
 		<label class="label-slide angular-animate" ng-show="dateTime.ngModel.$viewValue | isEmpty:false && dateTime.label">{{dateTime.label}}</label>
 		<input type="text" class="form-control" ng-model="dateTime.ngModel.$viewValue" placeholder="{{dateTime.label}}"/>
 		<span class="input-group-btn">


### PR DESCRIPTION
…class, `.datepicker-input-group`.

**Youtrack issue: https://renovo.myjetbrains.com/youtrack/issue/THM-66**
**Requires Theme PR: https://github.com/RenovoSolutions/RenovoTheme/pull/235**
- Removed `.show-date-picker` class from ng2 version, it's only needed for jQuery.
