### PR TITLE
Removing ng2-bootstrap tooltip from cardSearch

### DIFF
--- a/source/components/cardContainer/container/cardSearch/cardSearch.html
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.html
@@ -4,9 +4,6 @@
 	<rlTextbox [label]="searchPlaceholder"
 			   [value]="searchFilter.searchText || ''"
 			   (valueChange)="setSearch($event)"
-			   tooltip="You must enter at least {{searchFilter.minSearchLength}} characters to perform a search"
-			   tooltipTrigger="mouseenter"
-			   [tooltipEnable]="searchLengthError"></rlTextbox>
 	<div class="input-group-btn">
 		<rlButton [disabled]="searchFilter.searchText | isEmpty"
 				  (click)="setSearch(null)">

--- a/source/components/cardContainer/container/cardSearch/cardSearch.html
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.html
@@ -1,9 +1,11 @@
 <div class="input-group"
 	 *ngIf="hasSearchFilter"
-	 [class.has-error]="searchLengthError">
+	 [class.has-error]="searchLengthError"
+	 [class.rl-tooltip]="searchLengthError"
+	 [attr.data-tooltip]="You must enter at least {{searchFilter.minSearchLength}} characters to perform a search">
 	<rlTextbox [label]="searchPlaceholder"
 			   [value]="searchFilter.searchText || ''"
-			   (valueChange)="setSearch($event)"
+			   (valueChange)="setSearch($event)"></rlTextbox>
 	<div class="input-group-btn">
 		<rlButton [disabled]="searchFilter.searchText | isEmpty"
 				  (click)="setSearch(null)">

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit, Inject, forwardRef } from '@angular/core';
-import { TOOLTIP_DIRECTIVES } from 'ng2-bootstrap';
 
 import { services, filters } from 'typescript-angular-utilities';
 import __genericSearchFilter = services.genericSearchFilter;
@@ -16,7 +15,7 @@ export const defaultSearchDelay: number = 1000;
 @Component({
 	selector: 'rlCardSearch',
 	template: require('./cardSearch.html'),
-	directives: [TextboxComponent, ButtonComponent, TOOLTIP_DIRECTIVES],
+	directives: [TextboxComponent, ButtonComponent],
 	pipes: [__isEmpty.IsEmptyPipe],
 })
 export class CardSearchComponent<T> implements OnInit {


### PR DESCRIPTION
**Requires Theme PR: https://github.com/RenovoSolutions/RenovoTheme/pull/236**

Replaced with custom CSS tooltip.

![new-tooltip-ex2](https://cloud.githubusercontent.com/assets/13574057/18170994/595c7738-702e-11e6-9d7d-a728fe732317.gif)
