### PR TITLE
Since cardSearch now uses a css tooltip, we can now drop ng2-bootstrap

### DIFF
--- a/bootstrapper/popup/popupNg2.html
+++ b/bootstrapper/popup/popupNg2.html
@@ -1,7 +1,7 @@
 <h3>Popup content</h3>
 <div>
 	<label>Tooltip:</label>
-	<span class="btn btn-default" tooltip="A popover with {{content}}">Show tooltip</span>
+	<span class="btn btn-default rl-tooltip" data-tooltip="A popover with {{content}}">Show tooltip</span>
 </div>
 
 <div>

--- a/bootstrapper/popup/popupNg2Bootstrapper.ts
+++ b/bootstrapper/popup/popupNg2Bootstrapper.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { TOOLTIP_DIRECTIVES } from 'ng2-bootstrap';
 
 import { ButtonComponent } from '../../source/components/buttons/index';
 import { INPUT_DIRECTIVES } from '../../source/components/inputs/index';
@@ -13,7 +12,6 @@ import { DIALOG_TEMPLATE_DIRECTIVES } from '../../source/components/dialog/templ
 	selector: 'tsPopupBootstrapper',
 	template: require('./popupNg2.html'),
 	directives: [
-		TOOLTIP_DIRECTIVES,
 		ButtonComponent,
 		INPUT_DIRECTIVES,
 		DIALOG_TEMPLATE_DIRECTIVES,

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "moment": "~2.14.1",
     "moment-timezone": "^0.5.3",
     "ng-wig": "~2.3.4",
-    "ng2-bootstrap": "1.0.24",
     "rxjs": "5.0.0-beta.6",
     "signature_pad": "~1.5.3",
     "systemjs": "^0.19.28",

--- a/system.config.js
+++ b/system.config.js
@@ -14,7 +14,6 @@ const map = {
 	'lodash': 'node_modules/lodash/index',
 	'moment': 'node_modules/moment/moment',
 	'moment-timezone': 'node_modules/moment-timezone/builds/moment-timezone-with-data.min',
-	'ng2-bootstrap': 'node_modules/ng2-bootstrap/ng2-bootstrap.js',
 	'signature_pad': 'node_modules/signature_pad/signature_pad',
 	'ng-wig': 'node_modules/ng-wig',
 	'ui-select': 'node_modules/ui-select/index',


### PR DESCRIPTION
This will allow us to go to angular rc 5, which was previously held back by ng2-boostrap not on it yet.

This shouldn't any QA, since ng2-bootstrap wasn't used anymore. However, we'll want to drop it as an npm dependency in all of our dependent packages as well.
