### PR TITLE
Tooltip fix

### DIFF
--- a/source/components/cardContainer/container/cardSearch/cardSearch.html
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.html
@@ -2,7 +2,7 @@
 	 *ngIf="hasSearchFilter"
 	 [class.has-error]="searchLengthError"
 	 [class.rl-tooltip]="searchLengthError"
-	 [attr.data-tooltip]="You must enter at least {{searchFilter.minSearchLength}} characters to perform a search">
+	 [attr.data-tooltip]="minSearchError">
 	<rlTextbox [label]="searchPlaceholder"
 			   [value]="searchFilter.searchText || ''"
 			   (valueChange)="setSearch($event)"></rlTextbox>

--- a/source/components/cardContainer/container/cardSearch/cardSearch.tests.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.tests.ts
@@ -75,6 +75,11 @@ describe('CardSearchComponent', () => {
 		expect(cardSearch.searchPlaceholder).to.equal(cardContainer.searchPlaceholder);
 	});
 
+	it('should show an error for the minimum search length', () => {
+		cardSearch.searchFilter = <any>{ minSearchLength: 3 };
+		expect(cardSearch.minSearchError).to.equal('You must enter at least 3 characters to perform a search');
+	});
+
 	describe('search', (): void => {
 		beforeEach((): void => {
 			cardSearch.ngOnInit();

--- a/source/components/cardContainer/container/cardSearch/cardSearch.ts
+++ b/source/components/cardContainer/container/cardSearch/cardSearch.ts
@@ -24,7 +24,6 @@ export class CardSearchComponent<T> implements OnInit {
 
 	searchLengthError: boolean = false;
 	hasSearchFilter: boolean = true;
-	minSearchError: string;
 
 	cardContainer: CardContainerComponent<T>;
 	timer: __timeout.ITimeout;
@@ -68,7 +67,11 @@ export class CardSearchComponent<T> implements OnInit {
  		if (this.hasSearchFilter) {
  			return this.cardContainer.searchPlaceholder || defaultSearchPlaceholder;
  		}
- 	}
+	}
+
+	get minSearchError(): string {
+		return `You must enter at least ${this.searchFilter.minSearchLength} characters to perform a search`;
+	}
 
 	private validateSearchLength(search: string, minLength: number): void {
 		// show error if search string exists but is below minimum size

--- a/source/components/tabs/tab.css
+++ b/source/components/tabs/tab.css
@@ -1,7 +1,7 @@
-.tab-content .tab-pane { display: none }
-.tab-content .tab-pane.active { display: block }
+.rl-tab-content .rl-tab-pane { display: none }
+.rl-tab-content .rl-tab-pane.active { display: block }
 
-.nav-tabs li.error > a::before {
+.rl-tabset li.error > a::before {
     font-family: "FontAwesome";
     content: '\f071';
     color: #d50000;


### PR DESCRIPTION
In angular 2, it's not possible to mix [] and {{}} syntax. Addressed by moving the expression to the controller. This also makes it testable.
