### PR TITLE
Card search refine search

### DIFF
--- a/source/components/cardContainer/cardContainer.html
+++ b/source/components/cardContainer/cardContainer.html
@@ -15,17 +15,19 @@
 					</div>
 					<div class="clearfix"></div>
 				</div>
+
+				<div class="alert alert-info" [hidden]="hasItems">
+					Please refine your search results
+				</div>
+				<div class="alert alert-info" [hidden]="!dataSource.isEmpty">
+					There are no items to show
+				</div>
+
 				<div *ngIf="hasItems">
 					<div class="card-item-repeat" *ngFor="let card of dataSource.dataSet">
 						<rlCard [item]="card"
 								[save]="save"></rlCard>
 					</div>
-				</div>
-				<div class="alert alert-info" *ngIf="dataSource.needsRefinedSearch">
-					Please refine your search results
-				</div>
-				<div class="alert alert-info" *ngIf="dataSource.isEmpty">
-					There are no items to show
 				</div>
 
 				<div>

--- a/source/components/cardContainer/cardContainer.ng1.html
+++ b/source/components/cardContainer/cardContainer.ng1.html
@@ -39,6 +39,13 @@
 					</template>
 				</rl-generic-container>
 
+				<div class="alert alert-info" ng-show="!cardContainer.hasItems">
+					Please refine your search results
+				</div>
+				<div class="alert alert-info" ng-show="cardContainer.dataSource.isEmpty">
+					There are no items to show
+				</div>
+
 				<div ng-if="cardContainer.dataSource.dataSet | isEmpty:false">
 					<div class="card-item-repeat" ng-repeat="card in cardContainer.dataSource.dataSet">
 						<rl-card columns="cardContainer.columns" item="card"
@@ -53,12 +60,6 @@
 								card-as="cardContainer.cardAs"
 								save-when-invalid="cardContainer.saveWhenInvalid"></rl-card>
 					</div>
-				</div>
-				<div class="alert alert-info" ng-if="cardContainer.dataSource.needsRefinedSearch">
-					Please refine your search results
-				</div>
-				<div class="alert alert-info" ng-if="cardContainer.dataSource.isEmpty">
-					There are no items to show
 				</div>
 
 				<div>

--- a/source/components/cardContainer/cardContainer.ng1.tests.ts
+++ b/source/components/cardContainer/cardContainer.ng1.tests.ts
@@ -592,6 +592,27 @@ describe('CardContainerController', () => {
 		});
 	});
 
+	describe('hasItems', (): void => {
+		it('should return true if the data set is not empty', (): void => {
+			let dataSource: IDataSourceMock;
+			dataSource = buildMockedDataSource();
+			dataSource.rawDataSet = [
+				{ id: 0 },
+				{ id: 1 },
+			];
+			dataSource.dataSet = dataSource.rawDataSet;
+			buildController();
+
+			cardContainer.dataSource.dataSet = [];
+
+			expect(cardContainer.hasItems).to.be.false;
+
+			cardContainer.dataSource.dataSet = [1];
+
+			expect(cardContainer.hasItems).to.be.true;
+		});
+	});
+
 	function buildController(): void {
 		if (cardContainer.dataSource == null && builder._dataSource == null) {
 			mockedDataSource = buildMockedDataSource();

--- a/source/components/cardContainer/cardContainer.ng1.ts
+++ b/source/components/cardContainer/cardContainer.ng1.ts
@@ -240,6 +240,10 @@ export class CardContainerController {
 		this.selectionChangedEvent();
 	}
 
+	get hasItems(): boolean {
+		return this.dataSource.dataSet && !!this.dataSource.dataSet.length;
+	}
+
 	private syncFilters(): void {
 		if (!this.object.isNullOrEmpty(this.filters)) {
 			this.dataSource.filters = this.filters;


### PR DESCRIPTION
**Youtrack issue: https://renovo.myjetbrains.com/youtrack/issue/THM-71**

> Update 'empty' styling for 'Add test equipment'

So this works for now, but I'm not sure if it's the best way of going about it. The alerts didn't seem to appear at all before, though.

**Ng1**
![card-search-refine](https://cloud.githubusercontent.com/assets/13574057/18790784/10a31e6e-817e-11e6-9431-047911e62d0a.gif)

**Ng2**
![card-search-refine_ng2](https://cloud.githubusercontent.com/assets/13574057/18791074/48bc3cee-817f-11e6-9492-a08678c40551.gif)

**Add Test Equipment**
![card-search-refine_add_test](https://cloud.githubusercontent.com/assets/13574057/18791336/4bb618c4-8180-11e6-9147-eb812154c23c.gif)
