### PR TITLE
Wait to trigger a render until after the current execution loop

### DIFF
--- a/source/components/inputs/signature/signature.ts
+++ b/source/components/inputs/signature/signature.ts
@@ -61,7 +61,7 @@ export class SignatureComponent extends ValidatedInputComponent<string> implemen
 
 	ngAfterViewInit(): void {
 		super.ngAfterViewInit();
-		this.rendering = !this.disabled;
+		setTimeout(() => this.rendering = !this.disabled, 0);
 	}
 
 	ngOnChanges(changes: ISignatureChanges): void {


### PR DESCRIPTION
This seems to solve an issue where the jSignature control thinks its container has no size while it's in a context that's initializing. (Such as a dialog) This forces it to wait to render until after the dialog is fully open, thus sizing it correctly.
