### PR TITLE
Form improvements

### DIFF
--- a/bootstrapper/forms/formsNg2.html
+++ b/bootstrapper/forms/formsNg2.html
@@ -28,9 +28,12 @@
 </rlForm>
 <h5>Autosave form</h5>
 <rlBusy [loading]="autosaveAction.saving || autosaveAction.complete"></rlBusy>
-<rlForm [save]="waitCallback" rlAutosave>
+<rlForm #autosaveForm [save]="waitCallback" rlAutosave [saveWhenInvalid]="true">
 	<rlTextbox name="textbox1" label="Autosave textbox" rlRequired="Required textbox"></rlTextbox>
 </rlForm>
+{{autosaveForm.form.pristine ? 'Pristine' : 'Dirty'}}
+<rlButton (click)="autosaveForm.form.markAsPristine()">Mark as pristine</rlButton>
+<rlButton (click)="autosaveForm.reset()">Reset</rlButton>
 <h5>Broken validation</h5>
 <rlForm>
 	<rlTextbox [validator]="brokenValidator"></rlTextbox>

--- a/source/components/form/form.tests.ts
+++ b/source/components/form/form.tests.ts
@@ -58,6 +58,15 @@ describe('FormComponent', (): void => {
 		sinon.assert.calledWith(pushSpy, form.form);
 	});
 
+	it('should reset the form', () => {
+		const resetSpy = sinon.spy();
+		form.form.reset = resetSpy;
+
+		form.reset();
+
+		sinon.assert.calledOnce(resetSpy);
+	});
+
 	describe('saveForm', (): void => {
 		it('should mark the form as pristine after the submit completes', rlFakeAsync((): void => {
 			const saveMock = mock.promise();

--- a/source/components/form/form.tests.ts
+++ b/source/components/form/form.tests.ts
@@ -24,7 +24,9 @@ describe('FormComponent', (): void => {
 		formService = {};
 
 		form = new FormComponent(<any>notification, new AsyncHelper(), <any>formService, null);
-		form.form = <any>{};
+		form.form = <any>{
+			markAsPristine: sinon.spy(),
+		};
 	});
 
 	it('should default save if not specified', (): void => {
@@ -62,7 +64,7 @@ describe('FormComponent', (): void => {
 			const setPristineSpy = sinon.spy();
 			form.save = saveMock;
 			formService.isFormValid = <any>(() => true);
-			form.markAsPristine = setPristineSpy;
+			form.form.markAsPristine = setPristineSpy;
 
 			form.saveForm();
 
@@ -77,7 +79,7 @@ describe('FormComponent', (): void => {
 			form.save = <any>(() => null);
 			const setPristineSpy = sinon.spy();
 			formService.isFormValid = <any>(() => true);
-			form.markAsPristine = setPristineSpy;
+			form.form.markAsPristine = setPristineSpy;
 
 			form.saveForm();
 

--- a/source/components/form/form.ts
+++ b/source/components/form/form.ts
@@ -86,12 +86,6 @@ export class FormComponent {
 		return waitOn;
 	}
 
-	markAsPristine(): void {
-		// TODO: remove this once angular provides a way to mark as pristine or reset the form
-		(<any>this.form)._pristine = true;
-		(<any>this.form)._dirty = false;
-	}
-
 	private showErrors(): void {
 		const error = this.formService.getAggregateError(this.form);
 		if (error) {
@@ -102,6 +96,6 @@ export class FormComponent {
 	}
 
 	private resetAfterSubmit(waitOn: IWaitValue<any>): void {
-		this.asyncHelper.waitAsObservable(waitOn).subscribe(() => this.markAsPristine());
+		this.asyncHelper.waitAsObservable(waitOn).subscribe(() => this.form.markAsPristine());
 	}
 }

--- a/source/components/form/form.ts
+++ b/source/components/form/form.ts
@@ -80,6 +80,10 @@ export class FormComponent {
 		return this.formService.isFormValid(this.form);
 	}
 
+	reset(): void {
+		this.form.reset();
+	}
+
 	saveForm(): IWaitValue<any> {
 		const waitOn = this.save(this.form.value);
 		this.resetAfterSubmit(waitOn);


### PR DESCRIPTION
In one of the later RCs, angular introduced functionality for programmatically marking forms as pristine or dirty, as well as for resetting the form. Previously, we were manually doing this by setting the form's internal _dirty and _pristine properties, just as a short-term workaround. Update to use angular's method instead. Also expose a method for doing a full form reset if desired.

This should have no client-facing changes, else I would've waited for an opening in the WIP first. 
