### PR TITLE
Casting setTimeout() to any.

### DIFF
--- a/source/services/autosave/triggers/onChangeTrigger.ts
+++ b/source/services/autosave/triggers/onChangeTrigger.ts
@@ -61,7 +61,7 @@ export class OnChangeTrigger extends Trigger<OnChangeSettings> implements ITrigg
 			clearTimeout(this.timer);
 		}
 
-		this.timer = setTimeout(() => {
+		this.timer = <any>setTimeout(() => {
 			this.clearListener();
 			autosave();
 			this.$rootScope.$digest();


### PR DESCRIPTION
Currently in the core project we are using the AWS S3 SDK and it has a dependency on the @types/node which when we go to compile throws an error that we cannot cast this number to type Timer. I would prefer this to be a temporary solution until something better is found.
