### PR TITLE
On a change, reset the control value

### DIFF
--- a/source/components/inputs/signature/signature.tests.ts
+++ b/source/components/inputs/signature/signature.tests.ts
@@ -153,6 +153,48 @@ describe('SignatureComponent', () => {
 		});
 	});
 
+	describe('ngOnChanges', () => {
+		let canvas: ICanvasMock;
+
+		beforeEach(() => {
+			canvas = {
+				jSignature: sinon.spy(),
+			};
+			(signature as any)._canvas = canvas;
+		});
+
+		it('should reset the signature if the value is cleared', () => {
+			signature.lastInternalChange = '123';
+
+			signature.ngOnChanges(<any>{ value: { currentValue: null } });
+
+			sinon.assert.calledOnce(canvas.jSignature);
+			sinon.assert.calledWith(canvas.jSignature, 'reset');
+		});
+
+		it('should reset the signature and set the new value if the value is changed from outside', () => {
+			const newSignature = '123';
+
+			signature.ngOnChanges(<any>{ value: { currentValue: newSignature } });
+
+			sinon.assert.calledTwice(canvas.jSignature);
+			expect(canvas.jSignature.firstCall.args[0]).to.equal('reset');
+
+			const setArgs = canvas.jSignature.secondCall.args;
+			expect(setArgs[0]).to.equal('setData');
+			expect(setArgs[1]).to.equal(newSignature);
+		});
+
+		it('should ignore the change if it matches the last internal change', () => {
+			const updatedSignature = '123';
+			signature.lastInternalChange = updatedSignature;
+
+			signature.ngOnChanges(<any>{ value: { currentValue: updatedSignature } });
+
+			sinon.assert.notCalled(canvas.jSignature);
+		});
+	});
+
 	describe('reset', () => {
 		let canvas: ICanvasMock;
 

--- a/source/components/inputs/signature/signature.ts
+++ b/source/components/inputs/signature/signature.ts
@@ -16,6 +16,7 @@ import { emptySignature } from './emptySignature';
 
 export interface ISignatureChanges extends IInputChanges {
 	disabled: SimpleChange;
+	value: SimpleChange;
 }
 
 @Component({
@@ -47,6 +48,7 @@ export class SignatureComponent extends ValidatedInputComponent<string> implemen
 
 	rendering: boolean;
 	jquery: JQueryStatic;
+	lastInternalChange: string;
 
 	constructor( @Optional() rlForm: FormComponent
 			, componentValidator: ComponentValidator
@@ -69,6 +71,13 @@ export class SignatureComponent extends ValidatedInputComponent<string> implemen
 		if (changes.disabled) {
 			this.rendering = !changes.disabled.currentValue;
 		}
+
+		if (changes.value && this.canvas && changes.value.currentValue !== this.lastInternalChange) {
+			this.canvas.jSignature('reset');
+			if (changes.value.currentValue) {
+				this.canvas.jSignature('setData', changes.value.currentValue);
+			}
+		}
 	}
 
 	ngAfterViewChecked(): void {
@@ -86,6 +95,7 @@ export class SignatureComponent extends ValidatedInputComponent<string> implemen
 
 	onChange(): void {
 		const value: string = this.canvas.jSignature('getData', 'default');
+		this.lastInternalChange = value;
 		this.setValue(value);
 	}
 


### PR DESCRIPTION
For some reason I haven't been able to determine yet, the ngOnChanges hook gets fired with a change whenever the user draws on the control, so using the on-change hook at face value is causing a weird 'shift' issue. As a workaround, I'm saving the last internal change whenever the signature is updated from inside the control and comparing that against the value in the ngOnChanges hook.
