### PR TITLE
[Ng1] rlSelect, close multiple menus

### DIFF
--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -3,8 +3,9 @@
 		{{::select.label}}
 	</label>
 	<div class="form-control rl-select-trigger"
-		 ng-click="select.toggle()"
-		 ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }">
+		 ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }"
+		 ng-focus="select.openOptions()"
+		 ng-blur="select.closeOptions()"
 		<span class="placeholder" ng-hide="select.selection">{{::select.label}}</span>
 		<span class="rl-select-choice">{{select.getDisplayName(select.selection)}}</span>
 	</div>

--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -1,4 +1,4 @@
-<div class="field rl-select" ng-class="{ 'error': select.ngModel.$invalid, 'rl-select-loading': select.loading }" rl-off-click="select.close">
+<div class="field rl-select" ng-class="{ 'error': select.ngModel.$invalid, 'rl-select-loading': select.loading }">
 	<label ng-show="select.selection" class="label-slide angular-animate">
 		{{::select.label}}
 	</label>

--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -12,10 +12,10 @@
 		<span class="rl-select-choice">{{select.getDisplayName(select.selection)}}</span>
 	</div>
 	<ul class="rl-select-list" ng-if="select.showOptions">
-		<li class="rl-select-option rl-select-option-null" ng-if="::select.nullOption" ng-click="select.selectOption(null)">{{::select.nullOption}}</li>
+		<li class="rl-select-option rl-select-option-null" ng-if="::select.nullOption" ng-mousedown="select.selectOption(null)">{{::select.nullOption}}</li>
 		<li class="rl-select-option"
 			ng-repeat="$item in select.options"
-			ng-click="select.selectOption($item)">
+			ng-mousedown="select.selectOption($item)">
 			<rl-template-renderer template="select.template" rl-alias="$item as {{select.itemAs}}"></rl-template-renderer>
 		</li>
 	</ul>

--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -3,11 +3,10 @@
 		{{::select.label}}
 	</label>
 	<div class="form-control rl-select-trigger"
-		 ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }"
-		 ng-focus="select.openOptions()"
-		 ng-blur="select.closeOptions()"
-		 ng-mousedown="select.closeOptions()"
-		 tabindex="0">
+		ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }"
+		ng-mousedown="select.toggle()"
+		ng-blur="select.close()"
+		tabindex="0">
 		<span class="placeholder" ng-hide="select.selection">{{::select.label}}</span>
 		<span class="rl-select-choice">{{select.getDisplayName(select.selection)}}</span>
 	</div>

--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -6,6 +6,7 @@
 		 ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }"
 		 ng-focus="select.openOptions()"
 		 ng-blur="select.closeOptions()"
+		 tabindex="0">
 		<span class="placeholder" ng-hide="select.selection">{{::select.label}}</span>
 		<span class="rl-select-choice">{{select.getDisplayName(select.selection)}}</span>
 	</div>

--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -6,6 +6,7 @@
 		 ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }"
 		 ng-focus="select.openOptions()"
 		 ng-blur="select.closeOptions()"
+		 ng-mousedown="select.closeOptions()"
 		 tabindex="0">
 		<span class="placeholder" ng-hide="select.selection">{{::select.label}}</span>
 		<span class="rl-select-choice">{{select.getDisplayName(select.selection)}}</span>

--- a/source/components/inputs/select/select.ng1.tests.ts
+++ b/source/components/inputs/select/select.ng1.tests.ts
@@ -102,23 +102,17 @@ describe('SelectController', () => {
 			buildController();
 		});
 
-		it('should toggle the options', (): void => {
-			expect(dropdown.showOptions).to.be.undefined;
-
-			dropdown.toggle();
+		it('should open the options', (): void => {
+			dropdown.openOptions();
 
 			expect(dropdown.showOptions).to.be.true;
-
-			dropdown.toggle();
-
-			expect(dropdown.showOptions).to.be.false;
 		});
 
 		it('should close the options', (): void => {
-			dropdown.showOptions = true;
-			dropdown.close();
+			dropdown.closeOptions();
+
 			expect(dropdown.showOptions).to.be.false;
-		});
+		})
 
 		it('should do nothing if the options are already closed', (): void => {
 			dropdown.showOptions = false;

--- a/source/components/inputs/select/select.ng1.tests.ts
+++ b/source/components/inputs/select/select.ng1.tests.ts
@@ -111,7 +111,7 @@ describe('SelectController', () => {
 
 			dropdown.toggle();
 
-			expect(dropdown.showOptions).to.be.true;
+			expect(dropdown.showOptions).to.be.false;
 		});
 
 		it('should close the options', (): void => {

--- a/source/components/inputs/select/select.ng1.tests.ts
+++ b/source/components/inputs/select/select.ng1.tests.ts
@@ -114,12 +114,6 @@ describe('SelectController', () => {
 			expect(dropdown.showOptions).to.be.false;
 		})
 
-		it('should do nothing if the options are already closed', (): void => {
-			dropdown.showOptions = false;
-			dropdown.close();
-			expect(dropdown.showOptions).to.be.false;
-		});
-
 		it('should set the value and close the options', (): void => {
 			dropdown.showOptions = true;
 

--- a/source/components/inputs/select/select.ng1.tests.ts
+++ b/source/components/inputs/select/select.ng1.tests.ts
@@ -102,14 +102,21 @@ describe('SelectController', () => {
 			buildController();
 		});
 
-		it('should open the options', (): void => {
-			dropdown.openOptions();
+		it('should toggle the options', (): void => {
+			expect(dropdown.showOptions).to.be.undefined;
+
+			dropdown.toggle();
+
+			expect(dropdown.showOptions).to.be.true;
+
+			dropdown.toggle();
 
 			expect(dropdown.showOptions).to.be.true;
 		});
 
 		it('should close the options', (): void => {
-			dropdown.closeOptions();
+			dropdown.showOptions = true;
+			dropdown.close();
 
 			expect(dropdown.showOptions).to.be.false;
 		})

--- a/source/components/inputs/select/select.ng1.ts
+++ b/source/components/inputs/select/select.ng1.ts
@@ -92,14 +92,16 @@ export class SelectController extends InputController {
 		return promise;
 	}
 
-	toggle(): void {
-		this.showOptions = !this.showOptions;
+	openOptions(): void {
+		this.showOptions = true;
 	}
 
 	close: { (): void } = () => {
 		if (this.showOptions) {
 			this.showOptions = false;
 		}
+	closeOptions(): void {
+		this.showOptions = false;
 	}
 
 	selectOption(value: any): void {

--- a/source/components/inputs/select/select.ng1.ts
+++ b/source/components/inputs/select/select.ng1.ts
@@ -96,10 +96,6 @@ export class SelectController extends InputController {
 		this.showOptions = true;
 	}
 
-	close: { (): void } = () => {
-		if (this.showOptions) {
-			this.showOptions = false;
-		}
 	closeOptions(): void {
 		this.showOptions = false;
 	}

--- a/source/components/inputs/select/select.ng1.ts
+++ b/source/components/inputs/select/select.ng1.ts
@@ -92,11 +92,11 @@ export class SelectController extends InputController {
 		return promise;
 	}
 
-	openOptions(): void {
-		this.showOptions = true;
+	toggle(): void {
+		this.showOptions = !this.showOptions;
 	}
 
-	closeOptions(): void {
+	close(): void {
 		this.showOptions = false;
 	}
 


### PR DESCRIPTION
**Youtrack issue: https://renovo.myjetbrains.com/youtrack/issue/THM-74**

The original issue was that when you opened an rlSelect menu and then another rlSelect menu the first wouldn't close. So the menus would start to stack, or layer on top of one another.

This switches the ng1 select from using `ng-click` to using `ng-mousedown` and `ng-blur`. It also drops the need for the `rl-off-click` behavior.

These commits are a lot of trial and error. The last 4 commits are the final idea, once I figured out that `ng-focus` was breaking it and I could switch back to a toggle/close.

![ng1-select-fix](https://cloud.githubusercontent.com/assets/13574057/19196651/5e448a48-8c84-11e6-9ca8-774393e59646.gif)
