### PR TITLE
SPIKE - Step component

### DIFF
--- a/bootstrapper/bootstrapper.css
+++ b/bootstrapper/bootstrapper.css
@@ -1,3 +1,7 @@
 .rl-multi-step-item.error {
 	color: red;
 }
+
+.rl-multi-step-item.current {
+	color: blue;
+}

--- a/bootstrapper/bootstrapper.css
+++ b/bootstrapper/bootstrapper.css
@@ -1,7 +1,7 @@
-.rl-multi-step-item.error {
+.rl-tab-item.error {
 	color: red;
 }
 
-.rl-multi-step-item.current {
+.rl-tab-item.current {
 	color: blue;
 }

--- a/bootstrapper/bootstrapper.css
+++ b/bootstrapper/bootstrapper.css
@@ -1,0 +1,3 @@
+.rl-multi-step-item.error {
+	color: red;
+}

--- a/bootstrapper/msi/msi.ng2.html
+++ b/bootstrapper/msi/msi.ng2.html
@@ -6,6 +6,7 @@
 </rlMultiStepIndicator>
 <h3>rlStep</h3>
 <rlStep title="Inputs"
-		link="/inputs/ng2"></rlStep>
+		link="/inputs/ng2"
+		[valid]="false"></rlStep>
 <rlStep title="MSI"
 		link="../ng2"></rlStep>

--- a/bootstrapper/msi/msi.ng2.html
+++ b/bootstrapper/msi/msi.ng2.html
@@ -1,6 +1,11 @@
 <h3>Multi Step Indicator Angular 2</h3>
 <rlMultiStepIndicator
-    [numbered]="numbered"
-    [checked]="checked"
-    [steps]="steps">
+	[numbered]="numbered"
+	[checked]="checked"
+	[steps]="steps">
 </rlMultiStepIndicator>
+<h3>rlStep</h3>
+<rlStep title="Inputs"
+		link="/inputs/ng2"></rlStep>
+<rlStep title="MSI"
+		link="../ng2"></rlStep>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 		<link rel="stylesheet" href="/dist/components.css">
+		<link rel="stylesheet" href="/bootstrapper/bootstrapper.css">
 
 		<div>
 			<ts-app></ts-app>

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rxjs": "5.0.0-beta.12",
     "systemjs": "^0.19.28",
     "typescript": "^2.0.3",
-    "typescript-angular-utilities": "~3.8.0",
+    "typescript-angular-utilities": "~3.9.0",
     "ui-select": "~0.14.7",
     "zone.js": "~0.6.25"
   },

--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,7 +1,7 @@
 <li class="rl-multi-step-item"
 	[class.error]="valid == false"
 	[routerLink]="link"
-	[routerLinkActive]="activeClass">
+	routerLinkActive="current">
 	<div class="rl-item-wrap">
 		<p class="rl-item-title">{{title}}</p>
 	</div>

--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,0 +1,7 @@
+<li class="rl-multi-step-item"
+	[routerLink]="link"
+	[routerLinkActive]="activeClass">
+	<div class="rl-item-wrap">
+		<p class="rl-item-title">{{title}}</p>
+	</div>
+</li>

--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,4 +1,5 @@
 <li class="rl-multi-step-item"
+	[class.error]="valid == false"
 	[routerLink]="link"
 	[routerLinkActive]="activeClass">
 	<div class="rl-item-wrap">

--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,4 +1,4 @@
-<li class="rl-multi-step-item"
+<li class="{{stepClass}}"
 	[class.error]="valid == false"
 	[routerLink]="link"
 	routerLinkActive="current">

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -9,4 +9,5 @@ export class StepComponent {
 	@Input() title: string;
 	@Input() link: any[] | string;
 	@Input() activeClass: string = 'active';
+	@Input() valid: boolean;
 }

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -9,4 +9,11 @@ export class StepComponent {
 	@Input() title: string;
 	@Input() link: any[] | string;
 	@Input() valid: boolean;
+	@Input() msiStyling: boolean;
+
+	get stepClass(): string {
+		return this.msiStyling
+			? 'rl-multi-step-item'
+			: 'rl-tab-item';
+	}
 }

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
 	selector: 'rlStep',
 	template: require('./step.component.html'),
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StepComponent {
 	@Input() title: string;

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -8,6 +8,5 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 export class StepComponent {
 	@Input() title: string;
 	@Input() link: any[] | string;
-	@Input() activeClass: string = 'active';
 	@Input() valid: boolean;
 }

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -9,10 +9,10 @@ export class StepComponent {
 	@Input() title: string;
 	@Input() link: any[] | string;
 	@Input() valid: boolean;
-	@Input() msiStyling: boolean;
+	@Input() useMsiStyling: boolean;
 
 	get stepClass(): string {
-		return this.msiStyling
+		return this.useMsiStyling
 			? 'rl-multi-step-item'
 			: 'rl-tab-item';
 	}

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+	selector: 'rlStep',
+	template: require('./step.component.html'),
+})
+export class StepComponent {
+	@Input() title: string;
+	@Input() link: any[] | string;
+	@Input() activeClass: string = 'active';
+}

--- a/source/ui.module.ts
+++ b/source/ui.module.ts
@@ -13,7 +13,8 @@ import { FormComponent } from'./components/form/form';
 import { INPUT_DIRECTIVES } from'./components/inputs/index';
 import { MultiStepIndicatorComponent } from'./components/multiStepIndicator/multiStepIndicator';
 import { RatingBarComponent } from'./components/ratingBar/ratingBar';
-import { SIMPLE_CARD_DIRECTIVES } from'./components/simpleCardList/index';
+import { SIMPLE_CARD_DIRECTIVES } from './components/simpleCardList/index';
+import { StepComponent } from './components/multiStepIndicator/step.component';
 import { StringWithWatermarkComponent } from'./components/stringWithWatermark/stringWithWatermark';
 import { TABS_COMPONENT } from'./components/tabs/index';
 import { ValidationGroupComponent } from'./components/validationGroup/validationGroup';
@@ -43,6 +44,7 @@ export const componentsList: any[] = [
 	MultiStepIndicatorComponent,
 	RatingBarComponent,
 	SIMPLE_CARD_DIRECTIVES,
+	StepComponent,
 	StringWithWatermarkComponent,
 	TABS_COMPONENT,
 	ValidationGroupComponent,


### PR DESCRIPTION
Created a simple component for multi-step or tab links. The current multi-step indicator has issues with change detection because the steps are mutable. By making each step its own component, we can make the view a simple product of the inputs, which works well with OnPush change detection. 

Also, I discussed with @BrentWMiller  the possibility of making tab and MSI styling that uses very similar markup. In this component, we can support a flag that toggles the styling between a tab and MSI item, and this can then be used as a link of either type. (This will be useful for cases where we want a tab control that ties in with the url)
