### PR TITLE
Move initialization to $onInit

### DIFF
--- a/source/components/messageLog/messageLog.directive.tests.ts
+++ b/source/components/messageLog/messageLog.directive.tests.ts
@@ -301,6 +301,7 @@ describe('messageLog', () => {
 
 			scope = controllerResult.scope;
 			log = controllerResult.controller;
+			log.$onInit();
 		}
 	});
 

--- a/source/components/messageLog/messageLog.directive.ts
+++ b/source/components/messageLog/messageLog.directive.ts
@@ -96,7 +96,6 @@ export class MessageLogController implements IMessageLogBindings {
 		});
 
 		this.$scope.$watch((): IMessageLogDataService => { return this.service; }, (service: IMessageLogDataService): void => {
-			debugger;
 			this.messageLog.dataService = service;
 			this.loadingInitial = true;
 		});

--- a/source/components/messageLog/messageLog.directive.ts
+++ b/source/components/messageLog/messageLog.directive.ts
@@ -68,23 +68,25 @@ export class MessageLogController implements IMessageLogBindings {
 
 
 	static $inject: string[] = [__dialog.serviceName, '$scope', factoryName];
-	constructor(private dialog: __dialog.IDialogService<any>, $scope: ng.IScope, messageLogFactory: IMessageLogFactory) {
-		this.messageLog = this.messageLogBinding || messageLogFactory.getInstance();
+	constructor(private dialog: __dialog.IDialogService<any>, private $scope: ng.IScope, private messageLogFactory: IMessageLogFactory) {}
 
-		$scope.$watch((): IMessage[] => { return this.messageLog.visibleMessages; }
+	$onInit() {
+		this.messageLog = this.messageLogBinding || this.messageLogFactory.getInstance();
+
+		this.$scope.$watch((): IMessage[] => { return this.messageLog.visibleMessages; }
 			, (value: IMessage[]): void => {
 				this.messages = value;
 			});
 
-		$scope.$watch((): boolean => { return this.messageLog.hasForwardMessages; }, (value: boolean): void => {
+		this.$scope.$watch((): boolean => { return this.messageLog.hasForwardMessages; }, (value: boolean): void => {
 			this.hasNextPage = value;
 		});
 
-		$scope.$watch((): boolean => { return this.messageLog.hasBackwardMessages; }, (value: boolean): void => {
+		this.$scope.$watch((): boolean => { return this.messageLog.hasBackwardMessages; }, (value: boolean): void => {
 			this.hasPreviousPage = value;
 		});
 
-		$scope.$watch((): boolean => { return this.messageLog.busy; }, (value: boolean): void => {
+		this.$scope.$watch((): boolean => { return this.messageLog.busy; }, (value: boolean): void => {
 			if (!value) {
 				this.loading = false;
 				this.loadingInitial = false;
@@ -93,7 +95,8 @@ export class MessageLogController implements IMessageLogBindings {
 			}
 		});
 
-		$scope.$watch((): IMessageLogDataService => { return this.service; }, (service: IMessageLogDataService): void => {
+		this.$scope.$watch((): IMessageLogDataService => { return this.service; }, (service: IMessageLogDataService): void => {
+			debugger;
 			this.messageLog.dataService = service;
 			this.loadingInitial = true;
 		});


### PR DESCRIPTION
Sam: After further investigation, this isn't the root problem, but it's something that should be done. With angular 2 in place, bindings aren't usually setup in general until the $onInit hook
