### PR TITLE
Change select to just take a simple array instead of an observable

### DIFF
--- a/bootstrapper/inputs/inputsNg2.html
+++ b/bootstrapper/inputs/inputsNg2.html
@@ -34,7 +34,7 @@
 	<rlSelect [(value)]="selection" label="Select" [options]="options" transform="value">
 		<template let-option>#{{option.value}}</template>
 	</rlSelect>
-	<rlSelect name="select1" label="Select" [options]="optionsAsync" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
+	<rlSelect name="select1" label="Select" [options]="optionsAsync | async" transform="value" rlRequired="Required select" nullOption="None"></rlSelect>
 	<rlSelect [value]="selection" (change)="log($event)" label="Output event" [options]="options" transform="value"></rlSelect>
 </div>
 <div>

--- a/source/components/inputs/select/select.html
+++ b/source/components/inputs/select/select.html
@@ -15,13 +15,13 @@
 		<span class="rl-select-choice">{{getDisplayName(value)}}</span>
 	</div>
 	<rlPopoutList #list
-				  [options]="wrappedOptions"
+				  [options]="options"
 				  [template]="template"
 				  [transform]="transform"
 				  (select)="select($event)">
 		<rlPopoutItem class="rl-select-option-null" *ngIf="nullOption" (trigger)="select(null)">{{nullOption}}</rlPopoutItem>
 	</rlPopoutList>
-	<rlBusy></rlBusy>
+	<rlBusy [loading]="!options"></rlBusy>
 	<div *ngIf="componentValidator.error$ | async" class="error-string">
 		{{componentValidator.error$ | async}}
 	</div>

--- a/source/components/inputs/select/select.tests.ts
+++ b/source/components/inputs/select/select.tests.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { SelectComponent } from './select';
 
@@ -42,36 +42,6 @@ describe('SelectComponent', () => {
 			{ value: 4 },
 			{ value: 5 },
 		];
-	});
-
-	describe('after init', (): void => {
-		afterEach((): void => {
-			sinon.assert.calledOnce(busy.trigger);
-			sinon.assert.calledWith(busy.trigger, dropdown.wrappedOptions);
-		});
-
-		it('should wrap the array in an observable', (): void => {
-			const unwrapper: Sinon.SinonSpy = sinon.spy();
-			dropdown.options = options;
-
-			dropdown.ngAfterViewInit();
-			dropdown.wrappedOptions.subscribe(unwrapper);
-
-			sinon.assert.calledOnce(unwrapper);
-			sinon.assert.calledWith(unwrapper, options);
-		});
-
-		it('should leave the options untouched if already an observable', (): void => {
-			const unwrapper: Sinon.SinonSpy = sinon.spy();
-			const optionsStream: BehaviorSubject<ITestOption[]> = new BehaviorSubject(options);
-			dropdown.options = optionsStream;
-
-			dropdown.ngAfterViewInit();
-			dropdown.wrappedOptions.subscribe(unwrapper);
-
-			sinon.assert.calledOnce(unwrapper);
-			sinon.assert.calledWith(unwrapper, options);
-		});
 	});
 
 	it('should set the value and close the options', (): void => {

--- a/source/components/inputs/select/select.ts
+++ b/source/components/inputs/select/select.ts
@@ -1,6 +1,4 @@
 import { Component, Optional, Input, Output, ViewChild, ContentChild, AfterViewInit, TemplateRef } from '@angular/core';
-import { Observable } from 'rxjs';
-import { isArray } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
 import __object = services.object;
@@ -25,7 +23,7 @@ import { baseAnimations } from '../input';
 	animations: baseAnimations,
 })
 export class SelectComponent<T> extends ValidatedInputComponent<T> implements AfterViewInit {
-	@Input() options: T[] | Observable<T[]>;
+	@Input() options: T[];
 	@Input() transform: __transform.ITransform<T, string>;
 	@Input() nullOption: string;
 
@@ -36,7 +34,6 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 	@ViewChild(PopoutListComponent) list: PopoutListComponent<T>;
 	@ContentChild(TemplateRef) template: TemplateRef<any>;
 
-	wrappedOptions: Observable<T[]>;
 	private transformService: __transform.ITransformService;
 
 	constructor(transformService: __transform.TransformService
@@ -53,10 +50,6 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 	ngAfterViewInit(): void {
 		super.ngAfterViewInit();
 		this.template = this.template || this.externalTemplate;
-		this.wrappedOptions = isArray(this.options)
-							? Observable.of(<T[]>this.options)
-							: <Observable<T[]>>this.options;
-		this.busy.trigger(this.wrappedOptions);
 	}
 
 	select(value: T): void {

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -14,7 +14,7 @@
 			   rlPopoutTrigger
 			   (input)="searchStream.next($event.target.value)" />
 		<rlPopoutList [disabled]="!canShowOptions"
-					  [options]="visibleItems | async"
+					  [options]="visibleItems$ | async"
 					  [template]="template"
 					  [transform]="transform"
 					  (select)="selectItem($event)">

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -14,7 +14,7 @@
 			   rlPopoutTrigger
 			   (input)="searchStream.next($event.target.value)" />
 		<rlPopoutList [disabled]="!canShowOptions"
-					  [options]="visibleItems"
+					  [options]="visibleItems | async"
 					  [template]="template"
 					  [transform]="transform"
 					  (select)="selectItem($event)">

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -315,7 +315,7 @@ describe('TypeaheadComponent', () => {
 			typeahead.searchStream.next('search');
 			rlTick(DEFAULT_SERVER_SEARCH_DEBOUNCE);
 			flushMicrotasks();
-			typeahead.visibleItems.subscribe(data => visibleItems = data);
+			typeahead.visibleItems$.subscribe(data => visibleItems = data);
 			loadItems.flush();
 			loadItems.reset();
 			busy.trigger.reset();
@@ -353,7 +353,6 @@ describe('TypeaheadComponent', () => {
 			flushMicrotasks();
 
 			sinon.assert.calledTwice(busy.trigger);
-			sinon.assert.calledWith(busy.trigger, typeahead.visibleItems);
 			sinon.assert.calledOnce(loadItems);
 			sinon.assert.calledWith(loadItems, 'search2');
 

--- a/source/components/popoutList/popoutList.html
+++ b/source/components/popoutList/popoutList.html
@@ -1,6 +1,6 @@
-<ul class="rl-select-list" *ngIf="showOptions && !(isEmpty | async)">
+<ul class="rl-select-list" *ngIf="showOptions && !(isEmpty)">
 	<ng-content></ng-content>
-	<rlPopoutItem *ngFor="let option of options | async"
+	<rlPopoutItem *ngFor="let option of options"
 				  (trigger)="popoutListService.select.next(option)">
 		<span *ngIf="template">
 			<template [ngTemplateOutlet]="newTemplate()" [ngOutletContext]="{ $implicit: option }"></template>

--- a/source/components/popoutList/popoutList.tests.ts
+++ b/source/components/popoutList/popoutList.tests.ts
@@ -30,7 +30,7 @@ describe('PopoutListComponent', () => {
 		list = new PopoutListComponent<string>(transformService, <any>listService);
 
 		options = ['Option 1', 'Option 2', 'Option 3'];
-		list.options = Observable.of(options);
+		list.options = options;
 	});
 
 	it('should emit a select event when a select is triggered on the list service', (): void => {

--- a/source/components/popoutList/popoutList.ts
+++ b/source/components/popoutList/popoutList.ts
@@ -13,7 +13,7 @@ import { PopoutListService } from './popoutList.service';
 	template: require('./popoutList.html'),
 })
 export class PopoutListComponent<T> {
-	@Input() options: Observable<T[]>;
+	@Input() options: T[];
 	@Input() template: TemplateRef<any>;
 	@Input() transform: __transform.ITransform<T, string>;
 	@Output() select: EventEmitter<T> = new EventEmitter<T>();
@@ -39,10 +39,8 @@ export class PopoutListComponent<T> {
 		popoutListService.select.subscribe(value => this.select.emit(value));
 	}
 
-	get isEmpty(): Observable<boolean> {
-		return this.options
-			? this.options.map(x => !(x || x.length))
-			: Observable.of(true);
+	get isEmpty(): boolean {
+		return !(this.options && this.options.length);
 	}
 
 	get showOptions(): boolean {


### PR DESCRIPTION
Consumers can always pipe to async if they need an observable. We'll just show the busy spinner whenever the array is null. (Pass an empty array to show an 'empty' dropdown instead)
@jsommer made the suggestion.
