### PR TITLE
Step Component, MSI fix

### DIFF
--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,7 +1,5 @@
-<li [class.error]="valid == false"
-	[routerLink]="link"
-	routerLinkActive="current">
-	<div class="rl-item-wrap">
-		<p class="rl-item-title">{{title}}</p>
-	</div>
-</li>
+<div class="rl-item-wrap"
+		[routerLink]="link"
+		routerLinkActive="current">
+	<p class="rl-item-title">{{title}}</p>
+</div>

--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,5 +1,4 @@
-<li class="{{stepClass}}"
-	[class.error]="valid == false"
+<li [class.error]="valid == false"
 	[routerLink]="link"
 	routerLinkActive="current">
 	<div class="rl-item-wrap">

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -9,18 +9,35 @@ export class StepComponent {
 	@Input() title: string;
 	@Input() link: any[] | string;
 	@Input() valid: boolean;
+	@Input() current: boolean;
 	@Input() useMsiStyling: boolean = false;
 
+	// Default classes
+	@HostBinding('class.active') hasActive: boolean = true;
+
+	// Conditional classes
 	@HostBinding('class.rl-multi-step-item') useMsi: boolean = false;
 	@HostBinding('class.rl-tab-item') useTab: boolean = false;
+	@HostBinding('class.error') hasError: boolean = false;
 
 	ngOnInit() {
 		this.setStepType();
+		this.checkIfValid();
+	}
+
+	ngOnChanges() {
+		this.checkIfValid();
 	}
 
 	setStepType(): boolean {
 		return this.useMsiStyling
 			? this.useMsi = true
 			: this.useTab = true;
+	}
+
+	checkIfValid() {
+		this.valid
+			? this.hasError = false
+			: this.hasError = true;
 	}
 }

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -29,8 +29,8 @@ export class StepComponent {
 		this.checkIfValid();
 	}
 
-	setStepType(): boolean {
-		return this.useMsiStyling
+	setStepType() {
+		this.useMsiStyling
 			? this.useMsi = true
 			: this.useTab = true;
 	}

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -13,15 +13,15 @@ export class StepComponent {
 	@Input() useMsiStyling: boolean = false;
 
 	// Default classes
-	@HostBinding('class.active') hasActive: boolean = true;
+	@HostBinding('class.active') activeStyle: boolean = true;
 
 	// Conditional classes
-	@HostBinding('class.rl-multi-step-item') useMsi: boolean = false;
-	@HostBinding('class.rl-tab-item') useTab: boolean = false;
-	@HostBinding('class.error') hasError: boolean = false;
+	@HostBinding('class.rl-multi-step-item') msiStyle: boolean = false;
+	@HostBinding('class.rl-tab-item') tabStyle: boolean = false;
+	@HostBinding('class.error') errorStyle: boolean = false;
 
 	ngOnInit() {
-		this.setStepType();
+		this.setStepStyle();
 		this.checkIfValid();
 	}
 
@@ -29,15 +29,15 @@ export class StepComponent {
 		this.checkIfValid();
 	}
 
-	setStepType() {
+	setStepStyle() {
 		this.useMsiStyling
-			? this.useMsi = true
-			: this.useTab = true;
+			? this.msiStyle = true
+			: this.tabStyle = true;
 	}
 
 	checkIfValid() {
 		this.valid
-			? this.hasError = false
-			: this.hasError = true;
+			? this.errorStyle = false
+			: this.errorStyle = true;
 	}
 }

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, HostBinding, OnInit, OnChanges } from '@angular/core';
 
 @Component({
 	selector: 'rlStep',
@@ -9,11 +9,18 @@ export class StepComponent {
 	@Input() title: string;
 	@Input() link: any[] | string;
 	@Input() valid: boolean;
-	@Input() useMsiStyling: boolean;
+	@Input() useMsiStyling: boolean = false;
 
-	get stepClass(): string {
+	@HostBinding('class.rl-multi-step-item') useMsi: boolean = false;
+	@HostBinding('class.rl-tab-item') useTab: boolean = false;
+
+	ngOnInit() {
+		this.setStepType();
+	}
+
+	setStepType(): boolean {
 		return this.useMsiStyling
-			? 'rl-multi-step-item'
-			: 'rl-tab-item';
+			? this.useMsi = true
+			: this.useTab = true;
 	}
 }

--- a/source/components/multiStepIndicator/step.tests.ts
+++ b/source/components/multiStepIndicator/step.tests.ts
@@ -9,32 +9,32 @@ describe('StepComponent', () => {
 
 	it('should set the step styling to be a multi-step', (): void => {
 		step.useMsiStyling = true;
-		step.setStepType();
+		step.setStepStyle();
 
-		expect(step.useMsi).to.be.true;
-		expect(step.useTab).to.be.false;
+		expect(step.msiStyle).to.be.true;
+		expect(step.tabStyle).to.be.false;
 	});
 
 	it('should set the step styling to be a tab', (): void => {
 		step.useMsiStyling = false;
-		step.setStepType();
+		step.setStepStyle();
 
-		expect(step.useTab).to.be.true;
-		expect(step.useMsi).to.be.false;
+		expect(step.tabStyle).to.be.true;
+		expect(step.msiStyle).to.be.false;
 	});
 
 	it('should set error styling on the step if it isn\'t valid', (): void => {
 		step.valid = false;
 		step.checkIfValid();
 
-		expect(step.hasError).to.be.true;
+		expect(step.errorStyle).to.be.true;
 	});
 
 	it('should not set error styling on the step if it is valid', (): void => {
 		step.valid = true;
 		step.checkIfValid();
 
-		expect(step.hasError).to.be.false;
+		expect(step.errorStyle).to.be.false;
 	});
 
 });

--- a/source/components/multiStepIndicator/step.tests.ts
+++ b/source/components/multiStepIndicator/step.tests.ts
@@ -7,18 +7,20 @@ describe('StepComponent', () => {
 		step = new StepComponent;
 	});
 
-	it('should set the step styling to be a multi-step if using msi styling', (): void => {
+	it('should set the step styling to be a multi-step', (): void => {
 		step.useMsiStyling = true;
 		step.setStepType();
 
-		expect(step.setStepType).to.be.true;
+		expect(step.useMsi).to.be.true;
+		expect(step.useTab).to.be.false;
 	});
 
-	it('should set the step styling to be a tab if not using msi styling', (): void => {
+	it('should set the step styling to be a tab', (): void => {
 		step.useMsiStyling = false;
 		step.setStepType();
 
-		expect(step.setStepType).to.be.false;
+		expect(step.useTab).to.be.true;
+		expect(step.useMsi).to.be.false;
 	});
 
 	it('should set error styling on the step if it isn\'t valid', (): void => {

--- a/source/components/multiStepIndicator/step.tests.ts
+++ b/source/components/multiStepIndicator/step.tests.ts
@@ -1,0 +1,38 @@
+import { StepComponent } from './step.component';
+
+describe('StepComponent', () => {
+	let step: StepComponent;
+
+	beforeEach(() => {
+		step = new StepComponent;
+	});
+
+	it('should set the step styling to be a multi-step if using msi styling', (): void => {
+		step.useMsiStyling = true;
+		step.setStepType();
+
+		expect(step.setStepType).to.be.true;
+	});
+
+	it('should set the step styling to be a tab if not using msi styling', (): void => {
+		step.useMsiStyling = false;
+		step.setStepType();
+
+		expect(step.setStepType).to.be.false;
+	});
+
+	it('should set error styling on the step if it isn\'t valid', (): void => {
+		step.valid = false;
+		step.checkIfValid();
+
+		expect(step.hasError).to.be.true;
+	});
+
+	it('should not set error styling on the step if it is valid', (): void => {
+		step.valid = true;
+		step.checkIfValid();
+
+		expect(step.hasError).to.be.false;
+	});
+
+});


### PR DESCRIPTION
**Youtrack issue: https://renovo.myjetbrains.com/youtrack/issue/THM-80**
**Theme PR, with the needed changes: https://github.com/RenovoSolutions/RenovoTheme/pull/244**

Updated the step component to work with the MSI styling _(tab styling in the future)_. Since they both use flexbox to lay out their steps.

This change will use the host element as the 'list' item. So that the flexbox styling can be properly inherited.

These means we need to set classes on the host element instead.

![updated_step](https://cloud.githubusercontent.com/assets/13574057/19732364/8ec92414-9b6e-11e6-88f9-7f10e3a99ccc.gif)
