### PR TITLE
[Components] MSI and Tabs use same markup

### DIFF
--- a/source/components/multiStepIndicator/step.component.html
+++ b/source/components/multiStepIndicator/step.component.html
@@ -1,5 +1,5 @@
-<div class="rl-item-wrap"
+<div class="rl-step-wrap"
 		[routerLink]="link"
 		routerLinkActive="current">
-	<p class="rl-item-title">{{title}}</p>
+	<p class="rl-step-title">{{title}}</p>
 </div>

--- a/source/components/multiStepIndicator/step.component.ts
+++ b/source/components/multiStepIndicator/step.component.ts
@@ -13,26 +13,18 @@ export class StepComponent {
 	@Input() useMsiStyling: boolean = false;
 
 	// Default classes
+	@HostBinding('class.rl-step') stepStyle: boolean = true;
 	@HostBinding('class.active') activeStyle: boolean = true;
 
 	// Conditional classes
-	@HostBinding('class.rl-multi-step-item') msiStyle: boolean = false;
-	@HostBinding('class.rl-tab-item') tabStyle: boolean = false;
 	@HostBinding('class.error') errorStyle: boolean = false;
 
 	ngOnInit() {
-		this.setStepStyle();
 		this.checkIfValid();
 	}
 
 	ngOnChanges() {
 		this.checkIfValid();
-	}
-
-	setStepStyle() {
-		this.useMsiStyling
-			? this.msiStyle = true
-			: this.tabStyle = true;
 	}
 
 	checkIfValid() {

--- a/source/components/multiStepIndicator/step.tests.ts
+++ b/source/components/multiStepIndicator/step.tests.ts
@@ -7,22 +7,6 @@ describe('StepComponent', () => {
 		step = new StepComponent;
 	});
 
-	it('should set the step styling to be a multi-step', (): void => {
-		step.useMsiStyling = true;
-		step.setStepStyle();
-
-		expect(step.msiStyle).to.be.true;
-		expect(step.tabStyle).to.be.false;
-	});
-
-	it('should set the step styling to be a tab', (): void => {
-		step.useMsiStyling = false;
-		step.setStepStyle();
-
-		expect(step.tabStyle).to.be.true;
-		expect(step.msiStyle).to.be.false;
-	});
-
 	it('should set error styling on the step if it isn\'t valid', (): void => {
 		step.valid = false;
 		step.checkIfValid();

--- a/source/components/tabs/tabset.html
+++ b/source/components/tabs/tabset.html
@@ -1,11 +1,14 @@
 <div class="rl-tab">
-	<ul class="rl-tabset">
-		<li class="rl-tabset-item"
-			*ngFor="let tab of tabs" (click)="select(tab)"
-			[ngClass]="{ 'active': tab.isActive, 'error': !tab.isValid }">
-			<a class="rl-tabset-link"><span [innerHTML]="tab.header.innerHTML"></span></a>
-		</li>
-	</ul>
+	<div class="rl-step-list rl-tabset">
+		<div class="rl-step active"
+			 [class.error]="!tab.isValid"
+			 *ngFor="let tab of tabs" (click)="select(tab)">
+			<div class="rl-step-wrap"
+				 [class.current]="tab.isActive">
+				<span class="rl-step-title" [innerHTML]="tab.header.innerHTML"></span>
+			</div>
+		</div>
+	</div>
 	<div class="rl-tab-content">
 		<ng-content></ng-content>
 	</div>

--- a/source/components/tabs/tabset.ng1.html
+++ b/source/components/tabs/tabset.ng1.html
@@ -1,11 +1,14 @@
 <div class="rl-tab">
-	<ul class="rl-tabset">
-		<li class="rl-tabset-item"
+	<div class="rl-step-list rl-tabset">
+		<div class="rl-step active"
 			ng-repeat="tabHeader in tabset.tabHeaders" ng-click="tabset.select(tabHeader)"
-			ng-class="{ 'active': tabHeader.isVisible, 'error': !tabHeader.isValid }">
-			<a class="rl-tabset-link"><span ng-bind-html="tabHeader.template"></span></a>
-		</li>
-	</ul>
+			ng-class="{ 'error': !tabHeader.isValid }">
+			<div class="rl-step-wrap"
+				 ng-class="{ 'current': tabHeader.isVisible }">
+				<span class="rl-step-title" ng-bind-html="tabHeader.template"></span>
+			</div>
+		</div>
+	</div>
 	<div class="rl-tab-content">
 		<div ng-transclude></div>
 	</div>


### PR DESCRIPTION
**Youtrack issue: https://renovo.myjetbrains.com/youtrack/issue/THM-89**

**Requires a Theme and Core change:**
* **Theme PR: https://github.com/RenovoSolutions/RenovoTheme/pull/248**
* **Core PR: https://github.com/RenovoSolutions/RL21.Application.Core/pull/659**

Altering the markup for rlStep and Tabset so they use the same 'step' markup. This way we can just apply a single class to the wrapping div and it will set the style differences for each.

Removed methods/tests related to `[useMsiStyling]=""` as it won't be needed anymore. We can now just set the single wrapping class, instead of setting this attribute for each step.