### PR TITLE
Added an example of a dropdown and typeahead in a dialog

### DIFF
--- a/bootstrapper/popup/popupNg2.html
+++ b/bootstrapper/popup/popupNg2.html
@@ -18,6 +18,8 @@
 		<div *rlDialogHeader>Header 2</div>
 		<div *rlDialogContent>
 			<rlTextbox label="Textbox" name="textbox" rlRequired="Required"></rlTextbox>
+			<rlSelect label="Select" name="select" [options]="options" rlRequired="Required"></rlSelect>
+			<rlTypeahead label="Typeahead" name="typeahead" [getItems]="getOptions" rlRequired="Required" allowCollapse="true"></rlTypeahead>
 		</div>
 	</rlDialog>
 	<rlPromptDialog #prompt

--- a/bootstrapper/popup/popupNg2Bootstrapper.ts
+++ b/bootstrapper/popup/popupNg2Bootstrapper.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { IDialogClosingHandler } from '../../source/components/dialog/dialogRoot.service';
 
@@ -9,6 +10,8 @@ import { IDialogClosingHandler } from '../../source/components/dialog/dialogRoot
 export class PopupBootstrapper {
 	content: string = 'Some content';
 	onClosing: IDialogClosingHandler;
+	options = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+	getOptions = () => Observable.of(this.options);
 
 	constructor() {
 		this.onClosing = () => {


### PR DESCRIPTION
This is causing an issue where clicking on the scrollbar in the dropdown/typeahead closes the dropdown. By reproducing it here we can try out scenarios for fixing it.