### PR TITLE
Added support for setting an offClick directive as inactive

### DIFF
--- a/source/behaviors/offClick/offClick.ts
+++ b/source/behaviors/offClick/offClick.ts
@@ -1,4 +1,4 @@
-import { Directive, Host, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { Directive, Host, Input, Output, EventEmitter, OnInit, OnDestroy, SimpleChanges } from '@angular/core';
 
 import { services } from 'typescript-angular-utilities';
 import __guid = services.guid;
@@ -15,6 +15,7 @@ export interface IOffClickEvent extends MouseEvent {
 })
 export class OffClickDirective implements OnInit, OnDestroy {
 	@Output('offClick') offClick: EventEmitter<any> = new EventEmitter();
+	@Input('offClickActive') active: boolean = true;
 
 	listener: { ($event: MouseEvent): void } = ($event: IOffClickEvent) => {
 		if ($event.rlEventIdentifier !== this.identifier) {
@@ -29,13 +30,33 @@ export class OffClickDirective implements OnInit, OnDestroy {
 	}
 
 	ngOnInit() {
-		setTimeout(() => {
-			document.addEventListener('click', this.listener);
-		}, 0);
+		if (this.active) {
+			setTimeout(() => {
+				this.addListener();
+			});
+		}
+	}
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if (changes['active']) {
+			if (changes['active'].currentValue) {
+				this.addListener();
+			} else {
+				this.removeListener();
+			}
+		}
+	}
+
+	addListener(): void {
+		document.addEventListener('click', this.listener);
+	}
+
+	removeListener(): void {
+		document.removeEventListener('click', this.listener);
 	}
 
 	ngOnDestroy() {
-		document.removeEventListener('click', this.listener);
+		this.removeListener();
 	}
 
 	onClick($event: IOffClickEvent) {


### PR DESCRIPTION
The directive will watch for ngOnChanges and add and remove the event listener as needed. This is important because we might be going back to using off click for closing the popout list in our select and typeahead dropdowns. Without this change, that would mean that every dropdown and typeahead adds a document event to the page. Instead we can bind to offClickActive to only turn on the event listener when the dropdown is open, which will restrict us to one document listener at a time. (Only one dropdown should be able to open at a time)