### PR TITLE
Dropdowns click off to close

### DIFF
--- a/bootstrapper/popup/popupNg2.html
+++ b/bootstrapper/popup/popupNg2.html
@@ -18,8 +18,8 @@
 		<div *rlDialogHeader>Header 2</div>
 		<div *rlDialogContent>
 			<rlTextbox label="Textbox" name="textbox" rlRequired="Required"></rlTextbox>
-			<rlSelect label="Select" name="select" [options]="options" rlRequired="Required"></rlSelect>
-			<rlTypeahead label="Typeahead" name="typeahead" [getItems]="getOptions" rlRequired="Required" allowCollapse="true"></rlTypeahead>
+			<rlSelect label="Select" name="select" [options]="options" rlRequired="Required" nullOption="None"></rlSelect>
+			<rlTypeahead label="Typeahead" name="typeahead" [getItems]="getOptions" rlRequired="Required" allowCollapse="true" [create]="create"></rlTypeahead>
 		</div>
 	</rlDialog>
 	<rlPromptDialog #prompt

--- a/bootstrapper/popup/popupNg2Bootstrapper.ts
+++ b/bootstrapper/popup/popupNg2Bootstrapper.ts
@@ -31,4 +31,6 @@ export class PopupBootstrapper {
 	save = (data) => {
 		console.log(data);
 	}
+
+	create = x => x;
 }

--- a/source/behaviors/offClick/offClick.ts
+++ b/source/behaviors/offClick/offClick.ts
@@ -15,7 +15,17 @@ export interface IOffClickEvent extends MouseEvent {
 })
 export class OffClickDirective implements OnInit, OnDestroy {
 	@Output('offClick') offClick: EventEmitter<any> = new EventEmitter();
-	@Input('offClickActive') active: boolean = true;
+
+	private _active: boolean = true;
+	@Input('offClickActive') set active(value: boolean)
+	{
+		if (value) {
+			this.addListener();
+		} else {
+			this.removeListener();
+		}
+		this._active = value;
+	}
 
 	listener: { ($event: MouseEvent): void } = ($event: IOffClickEvent) => {
 		if ($event.rlEventIdentifier !== this.identifier) {
@@ -30,20 +40,10 @@ export class OffClickDirective implements OnInit, OnDestroy {
 	}
 
 	ngOnInit() {
-		if (this.active) {
+		if (this._active) {
 			setTimeout(() => {
 				this.addListener();
 			});
-		}
-	}
-
-	ngOnChanges(changes: SimpleChanges): void {
-		if (changes['active']) {
-			if (changes['active'].currentValue) {
-				this.addListener();
-			} else {
-				this.removeListener();
-			}
 		}
 	}
 

--- a/source/behaviors/offClick/offClick.ts
+++ b/source/behaviors/offClick/offClick.ts
@@ -1,4 +1,4 @@
-import { Directive, Host, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { Directive, Host, Input, Output, EventEmitter, OnInit, OnDestroy, SimpleChanges } from '@angular/core';
 
 import { services } from 'typescript-angular-utilities';
 import __guid = services.guid;
@@ -15,6 +15,7 @@ export interface IOffClickEvent extends MouseEvent {
 })
 export class OffClickDirective implements OnInit, OnDestroy {
 	@Output('offClick') offClick: EventEmitter<any> = new EventEmitter();
+	@Input('offClickActive') active: boolean = true;
 
 	listener: { ($event: MouseEvent): void } = ($event: IOffClickEvent) => {
 		if ($event.rlEventIdentifier !== this.identifier) {
@@ -29,13 +30,33 @@ export class OffClickDirective implements OnInit, OnDestroy {
 	}
 
 	ngOnInit() {
-		setTimeout(() => {
-			document.addEventListener('click', this.listener);
-		}, 0);
+		if (this.active) {
+			setTimeout(() => {
+				this.addListener();
+			});
+		}
+	}
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if (changes['active']) {
+			if (changes['active'].currentValue) {
+				this.addListener();
+			} else {
+				this.removeListener();
+			}
+		}
+	}
+
+	addListener(): void {
+		document.addEventListener('click', this.listener);
+	}
+
+	removeListener(): void {
+		document.removeEventListener('click', this.listener);
 	}
 
 	ngOnDestroy() {
-		document.removeEventListener('click', this.listener);
+		this.removeListener();
 	}
 
 	onClick($event: IOffClickEvent) {

--- a/source/behaviors/offClick/offClick.ts
+++ b/source/behaviors/offClick/offClick.ts
@@ -3,6 +3,8 @@ import { Directive, Host, Input, Output, EventEmitter, OnInit, OnDestroy, Simple
 import { services } from 'typescript-angular-utilities';
 import __guid = services.guid;
 
+import { DocumentWrapper } from '../../services/document/document.provider';
+
 export interface IOffClickEvent extends MouseEvent {
 	rlEventIdentifier: string;
 }
@@ -34,9 +36,12 @@ export class OffClickDirective implements OnInit, OnDestroy {
 	};
 
 	identifier: string;
+	document: Document;
 
-	constructor(guidService: __guid.GuidService) {
+	constructor(guidService: __guid.GuidService
+			, document: DocumentWrapper) {
 		this.identifier = guidService.random();
+		this.document = <any>document;
 	}
 
 	ngOnInit() {
@@ -48,11 +53,11 @@ export class OffClickDirective implements OnInit, OnDestroy {
 	}
 
 	addListener(): void {
-		document.addEventListener('click', this.listener);
+		this.document.addEventListener('click', this.listener);
 	}
 
 	removeListener(): void {
-		document.removeEventListener('click', this.listener);
+		this.document.removeEventListener('click', this.listener);
 	}
 
 	ngOnDestroy() {

--- a/source/componentProviders.module.ts
+++ b/source/componentProviders.module.ts
@@ -15,6 +15,7 @@ import { MergeSort } from './components/cardContainer/sorts/mergeSort/mergeSort.
 
 import { AsyncHelper } from './services/async/async.service';
 import { AutosaveActionService } from './services/autosaveAction/autosaveAction.service';
+import { DOCUMENT_PROVIDER } from './services/document/document.provider';
 import { DocumentService } from './services/documentWrapper/documentWrapper.service';
 import { FormService } from './services/form/form.service';
 import { JQUERY_PROVIDER } from './services/jquery/jquery.provider';
@@ -66,8 +67,9 @@ const defaultThemeNg1: FactoryProvider = {
 		DefaultTheme,
 		defaultThemeNg1,
 		DialogRootService,
-		FormService,
+		DOCUMENT_PROVIDER,
 		DocumentService,
+		FormService,
 		BreakpointService,
 		VisibleBreakpointService,
 		JQUERY_PROVIDER,

--- a/source/components/inputs/select/select.html
+++ b/source/components/inputs/select/select.html
@@ -3,25 +3,29 @@
 	 [class.error]="componentValidator.error$ | async"
 	 [class.rl-select-loading]="busy?.loading">
 	<label [@slide]="labelState">{{label}}</label>
-	<div class="form-control rl-select-trigger"
-		 [class.disabled]="disabled"
-		 [class.rl-select-open]="list.showOptions"
-		 (focus)="showLabel()"
-		 (blur)="hideLabelIfEmpty()"
-		 tabindex="0"
-		 rlPopoutTrigger>
-		<span class="placeholder"
-			  [class.hide-placeholder]="hidePlaceholder"
-			  [hidden]="value">{{label}}</span>
-		<span class="rl-select-choice">{{getDisplayName(value)}}</span>
+	<div class="rl-select-wrap"
+	 	 (offClick)="list.close()"
+	 	 [offClickActive]="list.showOptions">
+		<div class="form-control rl-select-trigger"
+			 [class.disabled]="disabled"
+			 [class.rl-select-open]="list.showOptions"
+			 (focus)="showLabel()"
+			 (blur)="hideLabelIfEmpty()"
+			 tabindex="0"
+			 rlPopoutTrigger>
+			<span class="placeholder"
+				  [class.hide-placeholder]="hidePlaceholder"
+				  [hidden]="value">{{label}}</span>
+			<span class="rl-select-choice">{{getDisplayName(value)}}</span>
+		</div>
+		<rlPopoutList #list
+					  [options]="options"
+					  [template]="template"
+					  [transform]="transform"
+					  (select)="select($event)">
+			<rlPopoutItem class="rl-select-option-null" *ngIf="nullOption" (trigger)="select(null)">{{nullOption}}</rlPopoutItem>
+		</rlPopoutList>
 	</div>
-	<rlPopoutList #list
-				  [options]="options"
-				  [template]="template"
-				  [transform]="transform"
-				  (select)="select($event)">
-		<rlPopoutItem class="rl-select-option-null" *ngIf="nullOption" (trigger)="select(null)">{{nullOption}}</rlPopoutItem>
-	</rlPopoutList>
 	<rlBusy [loading]="!options"></rlBusy>
 	<div *ngIf="componentValidator.error$ | async" class="error-string">
 		{{componentValidator.error$ | async}}

--- a/source/components/inputs/select/select.tests.ts
+++ b/source/components/inputs/select/select.tests.ts
@@ -44,29 +44,18 @@ describe('SelectComponent', () => {
 		];
 	});
 
-	it('should set the value and close the options', (): void => {
-		const closeSpy = sinon.spy();
-		dropdown.list = <any>{
-			close: closeSpy,
-		};
-
+	it('should set the value', (): void => {
 		dropdown.select(options[1]);
 
-		sinon.assert.calledOnce(closeSpy);
 		sinon.assert.calledOnce(setValue);
 		sinon.assert.calledWith(setValue, options[1]);
 	});
 
-	it('should close the options without setting the value if the current value is reselected', (): void => {
-		const closeSpy = sinon.spy();
-		dropdown.list = <any>{
-			close: closeSpy,
-		};
+	it('should not set the value if the current value is reselected', (): void => {
 		dropdown.value = options[1];
 
 		dropdown.select(options[1]);
 
-		sinon.assert.calledOnce(closeSpy);
 		sinon.assert.notCalled(setValue);
 	});
 

--- a/source/components/inputs/select/select.ts
+++ b/source/components/inputs/select/select.ts
@@ -31,7 +31,6 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 	@Input() externalTemplate: TemplateRef<any>;
 
 	@ViewChild(BusyComponent) busy: BusyComponent;
-	@ViewChild(PopoutListComponent) list: PopoutListComponent<T>;
 	@ContentChild(TemplateRef) template: TemplateRef<any>;
 
 	private transformService: __transform.ITransformService;
@@ -56,7 +55,6 @@ export class SelectComponent<T> extends ValidatedInputComponent<T> implements Af
 		if (value != this.value) {
 			this.setValue(value);
 		}
-		this.list.close();
 		this.hideLabelIfEmpty();
 	}
 

--- a/source/components/inputs/typeahead/typeahead.html
+++ b/source/components/inputs/typeahead/typeahead.html
@@ -3,25 +3,29 @@
 	 [class.error]="componentValidator.error$ | async">
 	<label [@slide]="labelState">{{label}}</label>
 	<div [hidden]="collapsed">
-		<input class="form-control rl-select-trigger"
-			   #input
-			   type="text"
-			   [disabled]="disabled"
-			   [class.rl-select-open]="list.showOptions"
-			   [class.hide-placeholder]="hidePlaceholder"
-			   [placeholder]="placeholder"
-			   [value]="search"
-			   (focus)="showLabel()"
-			   (blur)="hideLabelIfEmpty()"
-			   rlPopoutTrigger
-			   (input)="searchStream.next($event.target.value)" />
-		<rlPopoutList [disabled]="!canShowOptions"
-					  [options]="visibleItems$ | async"
-					  [template]="template"
-					  [transform]="transform"
-					  (select)="selectItem($event)">
-			<rlPopoutItem class="rl-select-option-custom" *ngIf="allowCustomOption" (trigger)="selectCustom()">{{search}}</rlPopoutItem>
-		</rlPopoutList>
+		<div class="rl-select-wrap"
+			 (offClick)="list.close()"
+			 [offClickActive]="list.showOptions || false">
+			<input class="form-control rl-select-trigger"
+				   #input
+				   type="text"
+				   [disabled]="disabled"
+				   [class.rl-select-open]="list.showOptions"
+				   [class.hide-placeholder]="hidePlaceholder"
+				   [placeholder]="placeholder"
+				   [value]="search"
+				   (input)="searchStream.next($event.target.value)"
+				   (focus)="showLabel()"
+				   (blur)="hideLabelIfEmpty()"
+				   rlPopoutTrigger />
+			<rlPopoutList [disabled]="!canShowOptions"
+						  [options]="visibleItems$ | async"
+						  [template]="template"
+						  [transform]="transform"
+						  (select)="selectItem($event)">
+				<rlPopoutItem class="rl-select-option-custom" *ngIf="allowCustomOption" (trigger)="selectCustom()">{{search}}</rlPopoutItem>
+			</rlPopoutList>
+		</div>
 	</div>
 	<div class="collapsed" [hidden]="!collapsed">
 		<span>{{getDisplayName(value)}}</span>

--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -38,7 +38,8 @@ describe('TypeaheadComponent', () => {
 			validate: sinon.spy(() => Observable.empty()),
 		};
 
-		typeahead = new TypeaheadComponent(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility);
+		const changeDetectorMock = { detectChanges: sinon.spy() };
+		typeahead = new TypeaheadComponent(__transform.transform, null, validator, __object.objectUtility, __array.arrayUtility, __guid.guid, __search.searchUtility, <any>changeDetectorMock);
 
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -116,7 +116,6 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 	}
 
 	selectItem(item: T): void {
-		this.list.close();
 		this.search = '';
 
 		this.selector.emit(item);

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, Optional, OnInit, OnChanges, SimpleChange, ViewChild, ContentChild, TemplateRef, ElementRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Optional, OnInit, OnChanges, SimpleChange, ViewChild, ContentChild, TemplateRef, ElementRef, ChangeDetectorRef } from '@angular/core';
 import { Observable, BehaviorSubject, Subject } from 'rxjs';
 import { find, filter, isEqual, cloneDeep } from 'lodash';
 
@@ -64,6 +64,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 
 	transformService: __transform.ITransformService;
 	searchUtility: __search.ISearchUtility;
+	changeDetector: ChangeDetectorRef;
 
 	get visibleItems$(): Observable<T[]> {
 		return this._visibleItems.asObservable();
@@ -83,10 +84,12 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 			, object: __object.ObjectUtility
 			, array: __array.ArrayUtility
 			, guid: __guid.GuidService
-			, searchService: __search.SearchUtility) {
+			, searchService: __search.SearchUtility
+			, changeDetector: ChangeDetectorRef) {
 		super(rlForm, componentValidator, object, array, guid);
 		this.transformService = transformService;
 		this.searchUtility = searchService;
+		this.changeDetector = changeDetector;
 		this.inputType = 'typeahead';
 		this.search = '';
 		this._visibleItems = new BehaviorSubject(null);
@@ -144,6 +147,7 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 				if (!isEqual(data, this.cacheDisplayList)) {
 					this.list.open();
 					this.cacheDisplayList = cloneDeep(data);
+					this.changeDetector.detectChanges();
 					return this._visibleItems.next(this.cacheDisplayList);
 				}
 			});

--- a/source/components/popoutList/popoutItem.html
+++ b/source/components/popoutList/popoutItem.html
@@ -1,6 +1,7 @@
 <li class="rl-select-option"
 	[class.focused]="focused"
 	(mouseover)="focus()"
-	(mouseleave)="blur()">
+	(mouseleave)="blur()"
+	(click)="select()">
 	<ng-content></ng-content>
 </li>

--- a/source/components/popoutList/popoutItem.ts
+++ b/source/components/popoutList/popoutItem.ts
@@ -26,4 +26,8 @@ export class PopoutItemComponent<T> {
 	blur(): void {
 		this.list.blur();
 	}
+
+	select(): void {
+		this.list.selectCurrent();
+	}
 }

--- a/source/components/popoutList/popoutList.service.tests.ts
+++ b/source/components/popoutList/popoutList.service.tests.ts
@@ -7,15 +7,6 @@ describe('PopoutListService', () => {
 		listService = new PopoutListService<string>();
 	});
 
-	it('should close the list on a select event', (): void => {
-		const closeSpy = sinon.spy();
-		listService.close = closeSpy;
-
-		listService.select.next('value');
-
-		sinon.assert.calledOnce(closeSpy);
-	});
-
 	describe('showOptions', (): void => {
 		it('should close the options', (): void => {
 			listService._showOptions = true;
@@ -167,6 +158,15 @@ describe('PopoutListService', () => {
 			listService.selectCurrent();
 
 			sinon.assert.notCalled(emitSpy);
+		});
+
+		it('should close the list on a selection', (): void => {
+			const closeSpy = sinon.spy();
+			listService.close = closeSpy;
+
+			listService.selectCurrent();
+
+			sinon.assert.calledOnce(closeSpy);
 		});
 	});
 });

--- a/source/components/popoutList/popoutList.service.ts
+++ b/source/components/popoutList/popoutList.service.ts
@@ -20,10 +20,6 @@ export class PopoutListService<T> {
 	customItems: QueryList<PopoutItemComponent<T>>;
 	listItems: QueryList<PopoutItemComponent<T>>;
 
-	constructor() {
-		this.select.subscribe(() => this.close());
-	}
-
 	open(): void {
 		this._showOptions = true;
 	}
@@ -78,6 +74,7 @@ export class PopoutListService<T> {
 			this.current.trigger.emit(null);
 			this.focusIndex = null;
 		}
+		this.close();
 	}
 
 	get current(): PopoutItemComponent<T> {

--- a/source/components/popoutList/popoutTrigger.ts
+++ b/source/components/popoutList/popoutTrigger.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, ElementRef } from '@angular/core';
+import { Directive, HostListener } from '@angular/core';
 
 import { PopoutListService } from './popoutList.service';
 
@@ -8,22 +8,21 @@ import { PopoutListService } from './popoutList.service';
 export class PopoutTriggerDirective {
 	@HostListener('keyup.arrowdown') downArrow = () => this.next();
 	@HostListener('keyup.arrowup') upArrow = () => this.previous();
-	@HostListener('blur') onBlur = () => this.select();
-	@HostListener('focus') onFocus = () => this.show();
-	@HostListener('keyup.enter') onEnter = () => this.elementRef.nativeElement.blur();
+	@HostListener('click') toggle = () => this.toggleList();
+	@HostListener('keyup.enter') onEnter = () => this.select();
 
 	popoutListService: PopoutListService<any>;
-	elementRef: ElementRef;
 
-	constructor(popoutListService: PopoutListService<any>
-			, elementRef: ElementRef) {
+	constructor(popoutListService: PopoutListService<any>) {
 		this.popoutListService = popoutListService;
-		this.elementRef = elementRef;
-		popoutListService.select.subscribe(() => elementRef.nativeElement.blur());
 	}
 
-	show(): void {
-		this.popoutListService.open();
+	toggleList(): void {
+		if (this.popoutListService.showOptions) {
+			this.popoutListService.close();
+		} else {
+			this.popoutListService.open();
+		}
 	}
 
 	next(): void {

--- a/source/services/document/document.provider.ts
+++ b/source/services/document/document.provider.ts
@@ -1,0 +1,8 @@
+import { ValueProvider } from '@angular/core';
+
+export abstract class DocumentWrapper { }
+
+export const DOCUMENT_PROVIDER: ValueProvider = {
+	provide: DocumentWrapper,
+	useValue: document,
+};


### PR DESCRIPTION
Don't use focus and blur as the open/close triggers for the list. This was causing issues with the list closing when the user tried to click on the scroll bar for the list. Instead we'll go back to using an off click trigger to close the list. The list will also close on selection. Also, the user can now toggle the list by clicking on the input itself, so they can open and close it as needed by that method. This should actually fix the gimicky behavior we were occasionally seeing in the importer, when somehow focus was lost but the list was still visible. The input no longer needs to be focused in order to select an item from the list, as long as the list is open.

**Slight feature regression:** tab will no longer select the currently highlighted item in the list. I tried to add a keyup.tab event listener, but it didn't seem to work. If we want to get this behavior back, we'll have to look at how angular does tab events.

Fixes https://renovo.myjetbrains.com/youtrack/issue/RLv21-123 for angular 2 dropdowns and typeaheads