### PR TITLE
Optional pageSize on editableMessageLog

### DIFF
--- a/source/components/messageLog/editableMessageLog.ts
+++ b/source/components/messageLog/editableMessageLog.ts
@@ -87,7 +87,7 @@ export function editableMessageLog(): angular.IDirective {
 		scope: {},
 		bindToController: {
 			service: '=',
-			pageSize: '=',
+			pageSize: '=?',
 			currentUser: '=?',
 			canDelete: '=?',
 		},


### PR DESCRIPTION
**YouTrack issue: https://renovo.myjetbrains.com/youtrack/issue/RLv2-1978**
> Fix non-performance decreasing console errors for RL2 message log improvements

This was done with the documentationMessageLog, but not the editable one. Should fix the error in the issue above.

**documentationMessageLog: https://github.com/RenovoSolutions/RL21.Application.Core/pull/720/commits/5537d2acd6dd9e1adc632429ddb475c457570e94**