### PR TITLE
NG1 Firefox select fix.

### DIFF
--- a/source/components/inputs/select/select.ng1.html
+++ b/source/components/inputs/select/select.ng1.html
@@ -2,7 +2,7 @@
 	<label ng-show="select.selection" class="label-slide angular-animate">
 		{{::select.label}}
 	</label>
-	<div class="rl-select-wrap" tabindex="0" ng-blur="select.close()">
+	<div class="rl-select-wrap" ng-class="{ 'rl-select-wrap-open': select.showOptions }" tabindex="0" ng-blur="select.close()">
 		<div class="form-control rl-select-trigger"
 			ng-class="{ 'disabled': select.ngDisabled, 'rl-select-open': select.showOptions }"
 			ng-mousedown="select.toggle()">


### PR DESCRIPTION
**YouTrack issue: https://renovo.myjetbrains.com/youtrack/issue/RLv21-123**

The positioning of the select list is `absolute` so its not accounted for in the ng-blur.

Using ng-class I can attach an `-open` to the wrap and style the list and such to work with ng-blur.

**Theme changes: https://github.com/RenovoSolutions/RenovoTheme/pull/268**