### PR TITLE
Spinner default to being blank

### DIFF
--- a/source/components/inputs/spinner/spinner.ts
+++ b/source/components/inputs/spinner/spinner.ts
@@ -70,7 +70,7 @@ export class SpinnerComponent extends ValidatedInputComponent<number> implements
 		}
 
 		super.ngAfterViewInit();
-		this.value = this.value || 0;
+		this.value = this.value;
 		this.setDisabled(this.disabled);
 		this.control.valueChanges.subscribe(value => {
 			const roundedValue: number = this.round(value);

--- a/source/components/inputs/spinner/spinner.ts
+++ b/source/components/inputs/spinner/spinner.ts
@@ -57,7 +57,6 @@ export class SpinnerComponent extends ValidatedInputComponent<number> implements
 		this.inputType = 'spinner';
 		this.numberUtility = number;
 		this.stringUtility = string;
-		this.showLabel();
 	}
 
 	focus(): void {


### PR DESCRIPTION
**YouTrack issue: https://renovo.myjetbrains.com/youtrack/issue/MUSIC-1302**
> Make labor and downtime inputs default cursor to the front of the time input and not at the end

> Acceptance Criteria:
> - The input needs to default to the front of the number input on the left side of the decimal number so that if the user clicks in the time entry area they can just type 1 and it will display it as 1.00 without having to move the cursor. 

This just removes the default of '0.00'. So the user doesn't have to backspace/delete anything. They can just type the number they want. Pretty much just a convenience change.

### Old
![spinner_oooold](https://cloud.githubusercontent.com/assets/13574057/24012750/7ffc68d2-0a55-11e7-8942-6851e7a87220.gif)

### New
![spinner_neeeeew](https://cloud.githubusercontent.com/assets/13574057/24012669/2d3c9d60-0a55-11e7-9f2d-97b653344874.gif)
