### PR TITLE
Add query params to buttonRoute

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/core-js": "0.9.35",
     "@types/jquery": "~2.0.32",
     "@types/jquery.jsignature": "~2.0.28",
-    "@types/lodash": "^4.14.53",
+    "@types/lodash": "4.14.53",
     "@types/moment-timezone": "^0.2.34",
     "@types/sinon": "^1.16.35",
     "chai": "~3.5.0",

--- a/source/components/buttons/buttonRoute/buttonRoute.html
+++ b/source/components/buttons/buttonRoute/buttonRoute.html
@@ -1,5 +1,6 @@
 <a class="btn {{configuredTypes}} {{configuredSize}}"
    [routerLink]="link"
+   [queryParams]="queryParams"
    [routerLinkActive]="activeClass"
    [target]="target"
    [class.disabled]="disabled">

--- a/source/components/buttons/buttonRoute/buttonRoute.ts
+++ b/source/components/buttons/buttonRoute/buttonRoute.ts
@@ -9,6 +9,7 @@ import { BaseButtonComponent, baseInputs } from '../baseButton';
 })
 export class ButtonRouteComponent extends BaseButtonComponent {
 	@Input() link: string;
+	@Input() queryParams: any;
 	@Input() activeClass: string = 'active';
 	@Input() newTab: boolean;
 


### PR DESCRIPTION
Now, the button route can specify a query string, and not just a page destination.