### PR TITLE
Updating typeahead so it always returns it's results.

### DIFF
--- a/source/components/inputs/typeahead/typeahead.tests.ts
+++ b/source/components/inputs/typeahead/typeahead.tests.ts
@@ -44,7 +44,7 @@ describe('TypeaheadComponent', () => {
 		setValue = sinon.spy();
 		typeahead.setValue = setValue;
 
-		busy = { waitOn: sinon.spy(x => x), waitOnObservableNext: sinon.spy(x => x), waitOnObservableCompletion: sinon.spy(x => x), setBusy: sinon.spy(x => x)};
+		busy = { waitOn: sinon.spy(x => x), waitOnObservableNext: sinon.spy(x => x), waitOnObservableCompletion: sinon.spy(x => x), setBusy: sinon.spy(x => x) };
 		typeahead.busy = <any>busy;
 		typeahead.list = <any>{
 			open: sinon.spy(),
@@ -303,7 +303,7 @@ describe('TypeaheadComponent', () => {
 			expect(typeahead.search).to.be.empty;
 		});
 
-		it('should only update when new value is emitted', rlFakeAsync(() => {
+		it('should always update when new value is emitted', rlFakeAsync(() => {
 			typeahead.clientSearch = true;
 			let listChangeDetector = sinon.spy();
 			let getItemsMock: IMockedRequest<string> = mock.request(items);
@@ -331,7 +331,7 @@ describe('TypeaheadComponent', () => {
 
 			getItemsMock.flush();
 
-			sinon.assert.calledThrice(listChangeDetector);
+			sinon.assert.callCount(listChangeDetector, 4);
 
 		}));
 

--- a/source/components/inputs/typeahead/typeahead.ts
+++ b/source/components/inputs/typeahead/typeahead.ts
@@ -146,11 +146,11 @@ export class TypeaheadComponent<T> extends ValidatedInputComponent<T> implements
 			// triggers the subscription
 			this.busy.waitOnObservableNext(loadRequest).subscribe(data => {
 				if (!isEqual(data, this.cacheDisplayList)) {
-					this.list.open();
 					this.cacheDisplayList = cloneDeep(data);
-					this.changeDetector.detectChanges();
-					return this._visibleItems.next(this.cacheDisplayList);
 				}
+				this.list.open();
+				this.changeDetector.detectChanges();
+				return this._visibleItems.next(this.cacheDisplayList);
 			});
 		}
 


### PR DESCRIPTION
in the Test Equipment Typeahead issues if you are to type RS get the results the add L to your search it hangs indefintitly because the list is not calling the open/detectChanges code. Because the Result set is the same as the previous query. by moving these actions out side of the coniditional it should cause results to always be displayed.