### PR TITLE
Remove alternate card logic

### DIFF
--- a/source/components/simpleCardList/simpleCardList.tests.ts
+++ b/source/components/simpleCardList/simpleCardList.tests.ts
@@ -6,7 +6,6 @@ import { SimpleCardListComponent } from './simpleCardList';
 interface ICardMock {
 	close?: sinon.SinonSpy;
 	alwaysOpen?: boolean;
-	alternatingClass?: string;
 }
 
 describe('SimpleCardListComponent', () => {
@@ -66,20 +65,5 @@ describe('SimpleCardListComponent', () => {
 		});
 
 		expect(card.alwaysOpen).to.be.true;
-	});
-
-	it('should set class card-odd on the even indexed cards', (): void => {
-		const card1: ICardMock = {};
-		const card2: ICardMock = {};
-		cards.push(<any>card1);
-		cards.push(<any>card2);
-		list.alwaysOpen = true;
-
-		list.ngAfterViewChecked();
-
-		expect(card1.alternatingClass).to.equal('card-odd');
-		expect(card1.alwaysOpen).to.be.true;
-		expect(card2.alternatingClass).to.be.empty;
-		expect(card2.alwaysOpen).to.be.true;
 	});
 });

--- a/source/components/simpleCardList/simpleCardList.ts
+++ b/source/components/simpleCardList/simpleCardList.ts
@@ -1,4 +1,4 @@
-import { Component, Input, SimpleChange, OnChanges, AfterViewChecked, ContentChildren, QueryList } from '@angular/core';
+import { Component, Input, SimpleChange, OnChanges, ContentChildren, QueryList } from '@angular/core';
 import { every, each } from 'lodash';
 
 import { services } from 'typescript-angular-utilities';
@@ -18,7 +18,7 @@ export interface IListChanges {
 				<ng-content></ng-content>
 			</span>`,
 })
-export class SimpleCardListComponent<T> implements OnChanges, AfterViewChecked {
+export class SimpleCardListComponent<T> implements OnChanges {
 	@Input() alwaysOpen: boolean;
 
 	@ContentChildren(SimpleCardComponent) cardChildren: QueryList<SimpleCardComponent<T>>;
@@ -43,17 +43,5 @@ export class SimpleCardListComponent<T> implements OnChanges, AfterViewChecked {
 		if (changes.alwaysOpen) {
 			each(this.cards, card => { card.alwaysOpen = changes.alwaysOpen.currentValue; });
 		}
-	}
-
-	ngAfterViewChecked(): void {
-		each(this.cards, (card: SimpleCardComponent<T>, index: number): void => {
-			// mark the even indexed cards as 'odd', since they are the first, third, etc in the view
-			card.alternatingClass = this.numberUtility.isEven(index)
-								? 'card-odd'
-								: '';
-			if (this.alwaysOpen != null) {
-				card.alwaysOpen = this.alwaysOpen;
-			}
-		});
 	}
 }


### PR DESCRIPTION
This logic is breaking angular change detection since it updates the alternatingClass property on each card after change detection has already run. This is now implemented via a css-only solution instead.

https://renovo.myjetbrains.com/youtrack/issue/RLv21-164