### PR TITLE
Fix for opening a dialog from a dialog

### DIFF
--- a/source/components/dialog/dialog.tests.ts
+++ b/source/components/dialog/dialog.tests.ts
@@ -41,27 +41,43 @@ describe('DialogComponent', (): void => {
 		expect(arg.autosave).to.equal(dialog.autosave);
 		expect(arg.size).to.equal(dialog.size);
 		expect(isFunction(arg.submitAndClose));
+
+		// cleanup active subscriptions
+		dialogRoot.closeDialog.next();
 	});
 
-	it('should fire a close event on the root', (): void => {
+	it('should fire a close event on the root if the dialog is active', (): void => {
 		const closeSpy = sinon.spy();
 		dialogRoot.closeDialog.subscribe(closeSpy);
+		dialog.isActive = true;
 
 		dialog.close();
 
 		sinon.assert.calledOnce(closeSpy);
 	});
 
-	it('should set dismissing and fire a close event on the root', (): void => {
+	it('should set dismissing and fire a close event on the root if the dialog is active', (): void => {
 		expect(dialogRoot.dismissing).to.be.false;
 
 		const closeSpy = sinon.spy();
 		dialogRoot.closeDialog.subscribe(closeSpy);
+		dialog.isActive = true;
 
 		dialog.dismiss();
 
 		expect(dialogRoot.dismissing).to.be.true;
 		sinon.assert.calledOnce(closeSpy);
+	});
+
+	it('should do nothing if the dialog is inactive', (): void => {
+		const closeSpy = sinon.spy();
+		dialogRoot.closeDialog.subscribe(closeSpy);
+		dialog.isActive = false;
+
+		dialog.close();
+		dialog.dismiss();
+
+		sinon.assert.notCalled(closeSpy);
 	});
 
 	describe('submitAndClose', (): void => {
@@ -75,6 +91,7 @@ describe('DialogComponent', (): void => {
 			dialog.submitAndWait = submitAndWaitSpy;
 			closeSpy = sinon.spy();
 			dialog.close = closeSpy;
+			dialog.isActive = true;
 		});
 
 		it('should close the dialog when the submit completes', (): void => {

--- a/source/components/dialog/dialog.ts
+++ b/source/components/dialog/dialog.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs';
+import { Subject } from 'rxjs/Subject';
 import { Component, Input, ContentChild, forwardRef } from '@angular/core';
 
 import { services } from 'typescript-angular-utilities';
@@ -31,6 +32,7 @@ export class DialogComponent extends FormComponent {
 	@ContentChild(DialogFooterTemplate) footer: DialogFooterTemplate;
 
 	dialogRoot: DialogRootService;
+	isActive: boolean;
 
 	constructor(notification: __notification.NotificationService
 		, asyncHelper: AsyncHelper
@@ -52,18 +54,35 @@ export class DialogComponent extends FormComponent {
 			submitAndClose: () => this.submitAndClose(),
 			size: this.size,
 		});
+		const inactive$ = new Subject()
+		this.dialogRoot.openDialog.takeUntil(inactive$).subscribe(() => {
+			this.isActive = false;
+			inactive$.next();
+		});
+		this.dialogRoot.closeDialog.takeUntil(inactive$).subscribe(() => {
+			this.isActive = false
+			inactive$.next();
+		});
 	}
 
 	close(): void {
-		this.dialogRoot.closeDialog.next(null);
+		if (this.isActive) {
+			this.dialogRoot.closeDialog.next(null);
+		}
 	}
 
 	dismiss(): void {
-		this.dialogRoot.dismissing = true;
-		this.dialogRoot.closeDialog.next(null);
+		if (this.isActive) {
+			this.dialogRoot.dismissing = true;
+			this.dialogRoot.closeDialog.next(null);
+		}
 	}
 
 	submitAndClose = (): Observable<any> => {
+		if (!this.isActive) {
+			return;
+		}
+
 		const waitOn = this.submitAndWait();
 		return this.asyncHelper.waitAsObservable(waitOn).do((result) => {
 			if (result !== false) {

--- a/source/components/dialog/dialog.ts
+++ b/source/components/dialog/dialog.ts
@@ -79,10 +79,6 @@ export class DialogComponent extends FormComponent {
 	}
 
 	submitAndClose = (): Observable<any> => {
-		if (!this.isActive) {
-			return;
-		}
-
 		const waitOn = this.submitAndWait();
 		return this.asyncHelper.waitAsObservable(waitOn).do((result) => {
 			if (result !== false) {


### PR DESCRIPTION
When one dialog wants to open from another, currently they both get closed immediately, since the second dialog opens and then the first one immediately closes. I tried adding a timeout or changing the order so the old dialog closes first, but this only seems to result in two overlays. Instead, we can actually fix this by disabling close events from a dialog unless it is the currently active dialog. If a second dialog opens up, the first dialog gets marked as inactive and close events are ignored from it. This way, the dialog outlet template simply gets replaced and the dialog outlet doesn't need to be closed and reopened.