### PR TITLE
Clear the active dialog context on close

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-components",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Reusable responsive angular components",
   "author": "Renovo Development Team",
   "keywords": [

--- a/source/components/dialog/dialogOutlet.ts
+++ b/source/components/dialog/dialogOutlet.ts
@@ -22,6 +22,7 @@ export class DialogOutletComponent implements AfterViewInit {
 			this.jquery('.rlModal').modal('show');
 		});
 		dialogRoot.closeDialog.subscribe((): void => {
+			dialogRoot.dialogContext = null;
 			this.jquery('.rlModal').modal('hide');
 		});
 		this.dialogSize$ = dialogRoot.openDialog.map(dialog => {


### PR DESCRIPTION
Currently, if the dialog is closed, the isOpen() method on the dialog component will return true as long as it was the last opened dialog. The easiest way to fix this is to wipe out the context when the dialog closes, so we can always tell that if there is a dialog context set, that dialog is open.