### PR TITLE
added touch start and touch end directive to NG1 long click button.

### DIFF
--- a/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
@@ -1,6 +1,9 @@
 <button class="btn btn-long-click {{button.types}} {{button.configuredSize}}"
 		ng-class="{ 'btn-loading': button.busy }"
 		ng-mousedown="button.startAction()" ng-mouseleave="button.stopAction()" ng-mouseup="button.stopAction()"
+		my-touchstart="button.startAction()"
+		my-touchend="button.stopAction()"
+
 		ng-disabled="button.busy || button.ngDisabled">
 	<span ng-transclude class="long-click-text btn-content">
 		<i ng-show="button.icon != null" class="fa fa-{{button.icon}}"></i> {{button.text}}

--- a/source/components/buttons/buttonLongClick/buttonLongClick.ng1.ts
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.ng1.ts
@@ -86,4 +86,27 @@ let longClickButton: angular.IComponentOptions = buildButton({
 
 angular.module(moduleName, [downgrade.moduleName, promiseModuleName])
 	.component(componentName, longClickButton)
-	.controller(controllerName, LongClickButtonController);
+	.controller(controllerName, LongClickButtonController)
+	.directive('myTouchstart', [function () {
+		return function(scope, element, attr) {
+
+			element.on('touchstart', function(event) {
+				scope.$apply(function() {
+					scope.$eval(attr.myTouchstart);
+				});
+
+				event.preventDefault();
+			});
+		};
+	}]).directive('myTouchend', [function() {
+		return function(scope, element, attr) {
+
+			element.on('touchend', function(event) {
+				scope.$apply(function() {
+					scope.$eval(attr.myTouchend);
+				});
+
+				event.preventDefault();
+			});
+		};
+	}]);


### PR DESCRIPTION
Long click button wasn't working on mobile/touch screen in rl2. This is because touch events are fired instead of click events when browsers sense touch screens