### PR TITLE
Type of button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-angular-components",
-    "version": "4.4.4",
+    "version": "4.4.5",
     "description": "Reusable responsive angular components",
     "author": "Renovo Development Team",
     "keywords": [

--- a/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
+++ b/source/components/buttons/buttonLongClick/buttonLongClick.ng1.html
@@ -1,4 +1,5 @@
 <button class="btn btn-long-click {{button.types}} {{button.configuredSize}}"
+		type="button"
 		ng-class="{ 'btn-loading': button.busy }"
 		ng-mousedown="button.startAction()" ng-mouseleave="button.stopAction()" ng-mouseup="button.stopAction()"
 		my-touchstart="button.startAction()"


### PR DESCRIPTION
On certain pages, short clicking a long click button is causing the form to get submitted. This is because by default buttons are tied to the submit action unless the button type is explicitly set to 'button'. This usually isn't an issue for us because it only affects where we use ASP.NET forms with a default post action.

https://renovo.myjetbrains.com/youtrack/issue/RLv2-2049